### PR TITLE
Remove dead code. Don't call into printf().

### DIFF
--- a/src/cpplexer/re2clex/cpp_re.cpp
+++ b/src/cpplexer/re2clex/cpp_re.cpp
@@ -216,13 +216,8 @@ uchar *fill(Scanner *s, uchar *cursor)
             uchar *buf = (uchar*) malloc(((s->lim - s->bot) + BOOST_WAVE_BSIZE)*sizeof(uchar));
             if (buf == 0)
             {
-                using namespace std;      // some systems have printf in std
-                if (0 != s->error_proc) {
-                    (*s->error_proc)(s, lexing_exception::unexpected_error,
-                        "Out of memory!");
-                }
-                else
-                    printf("Out of memory!\n");
+                (*s->error_proc)(s, lexing_exception::unexpected_error,
+                    "Out of memory!");
 
                 /* get the scanner to stop */
                 *cursor = 0;


### PR DESCRIPTION
There already seems to be an assertion in place that s->error_proc
cannot be NULL. There are also various other parts of code that call
into this function without checking for NULL first.

The intent of this change is that it makes this code build with
Nuxi CloudABI[1]. CloudABI is a sandboxed runtime computing environment.
As it is mainly oriented towards running (networked) services, it does
not understand the concept of stdin and stdout.

[1] Nuxi CloudABI: https://github.com/NuxiNL/cloudlibc