### PR TITLE
Honor --bindir and --libdir options if present when building wave.

### DIFF
--- a/tool/build/Jamfile.v2
+++ b/tool/build/Jamfile.v2
@@ -13,6 +13,7 @@
 # in the Wave tool anyway.
 
 import feature ;
+import option ;
 
 feature.feature wavetool 
     : on 
@@ -47,13 +48,16 @@ exe wave
     :
     release
     ;
+    
+local bindir = [ option.get bindir : ../../../dist/bin ] ;
+local libdir = [ option.get libdir : ../../../dist/lib ] ;
 
 install dist-bin
     :
     wave
     :
     <install-type>EXE
-    <location>../../../dist/bin
+    <location>$(bindir)
     :
     release
     ;
@@ -63,7 +67,7 @@ install dist-lib
     wave
     :
     <install-type>LIB
-    <location>../../../dist/lib
+    <location>$(libdir)
     :
     release
     ;


### PR DESCRIPTION
You should be able to tell the wave tool to build its libraries and/or executable outside of the Boost tree using the --libdir and/or --bindir command line options. The current build jamfile hardcodes the final lib and exe directory within the Boost tree. This fix allows the end-user to change that if he so desires.