### PR TITLE
Preventing macro repetition.

### DIFF
--- a/include/boost/wave/wave_config.hpp
+++ b/include/boost/wave/wave_config.hpp
@@ -186,7 +186,9 @@
 #endif
 
 #if BOOST_WAVE_SUPPORT_THREADING != 0 
-#define BOOST_SPIRIT_THREADSAFE 1
+#ifndef BOOST_SPIRIT_THREADSAFE
+#define BOOST_SPIRIT_THREADSAFE
+#endif
 #define PHOENIX_THREADSAFE 1
 #else
 // disable thread support in Boost.Pool


### PR DESCRIPTION
Macro repetition must be avoided to prevent clash with the other libraries.

A clash example is [here](https://github.com/Arash-codedev/Simple-Web-Server/blob/master/http_examples.cpp#L5)
