### PR TITLE
Remove fs access, step 1

### DIFF
--- a/include/boost/wave/cpp_context.hpp
+++ b/include/boost/wave/cpp_context.hpp
@@ -329,7 +329,7 @@ protected:
                 using namespace boost::filesystem;
                 path fpath(util::complete_path(path(filename)));
                 fname = fpath.string();
-                includes.set_current_directory(fname.c_str());
+                includes.set_current_directory(fname.c_str(), false);
             }
             has_been_initialized = true;  // execute once
         }
@@ -340,8 +340,8 @@ protected:
         { return macros.is_defined(begin, end); }
 
 // maintain include paths (helper functions)
-    void set_current_directory(char const *path_) 
-        { includes.set_current_directory(path_); }
+    void set_current_directory(char const *path_, bool directory_exists) 
+        { includes.set_current_directory(path_, directory_exists); }
 
 // conditional compilation contexts
     bool get_if_block_status() const { return ifblocks.get_status(); }

--- a/include/boost/wave/util/cpp_include_paths.hpp
+++ b/include/boost/wave/util/cpp_include_paths.hpp
@@ -161,7 +161,7 @@ public:
     void set_sys_include_delimiter() { was_sys_include_path = true; }
     bool find_include_file (std::string &s, std::string &dir, bool is_system, 
         char const *current_file) const;
-    void set_current_directory(char const *path_);
+    void set_current_directory(char const *path_, bool directory_exists);
     boost::filesystem::path get_current_directory() const 
         { return current_dir; }
 
@@ -435,13 +435,13 @@ as_relative_to(boost::filesystem::path const& path,
 
 ///////////////////////////////////////////////////////////////////////////////
 inline
-void include_paths::set_current_directory(char const *path_)
+void include_paths::set_current_directory(char const *path_, bool directory_exists)
 {
     namespace fs = boost::filesystem;
     
     fs::path filepath (create_path(path_));
     fs::path filename = util::complete_path(filepath, current_dir);
-    if (fs::exists(filename) && fs::is_directory(filename)) {
+    if (directory_exists) {
         current_rel_dir.clear();
         if (!as_relative_to(filepath, current_dir, current_rel_dir))
             current_rel_dir = filepath;

--- a/include/boost/wave/util/cpp_iterator.hpp
+++ b/include/boost/wave/util/cpp_iterator.hpp
@@ -434,7 +434,7 @@ pp_iterator_functor<ContextT>::returned_from_include()
         std::string real_filename(rfp.string());
         ctx.set_current_filename(real_filename.c_str());
 #endif
-        ctx.set_current_directory(iter_ctx->real_filename.c_str());
+        ctx.set_current_directory(iter_ctx->real_filename.c_str(), false);
         ctx.set_current_relative_filename(iter_ctx->real_relative_filename.c_str());
 
     // ensure the integrity of the #if/#endif stack
@@ -1605,7 +1605,7 @@ char const *current_name = 0;   // never try to match current file name
 #endif
     {
     // the new include file determines the actual current directory
-        ctx.set_current_directory(native_path_str.c_str());
+        ctx.set_current_directory(native_path_str.c_str(), false);
 
     // preprocess the opened file
     boost::shared_ptr<base_iteration_context_type> new_iter_ctx (


### PR DESCRIPTION
Every called of include_paths::set_current_directory knows that path
argument is a name of a file (not a directory name).

Please don't apply this patch.