### PR TITLE
Don't try to access act_token when it is not valid

### DIFF
--- a/include/boost/wave/util/cpp_iterator.hpp
+++ b/include/boost/wave/util/cpp_iterator.hpp
@@ -607,7 +607,7 @@ pp_iterator_functor<ContextT>::operator()()
         break;
     }
 
-    if (whitespace.must_insert(id, act_token.get_value())) {
+    if (token_is_valid(act_token) && whitespace.must_insert(id, act_token.get_value())) {
     // must insert some whitespace into the output stream to avoid adjacent
     // tokens, which would form different (and wrong) tokens
         whitespace.shift_tokens(T_SPACE);


### PR DESCRIPTION
`lex_token::get_value` assumes that `lex_token::data` is not NULL. When it
is NULL it causes UB detectable by clang's AddressSanitizer:

cpp_lex_token.hpp:242:57: runtime error: member call on null pointer of
type `boost::wave::cpplexer::impl::token_data...`


Another way to fix this - return default-constructed lex_token::string_type, but lex_token::get_value returns it by reference, so it has to be stored somewhere.
