### PR TITLE
feature/no new line warning in c++11

### DIFF
--- a/include/boost/wave/language_support.hpp
+++ b/include/boost/wave/language_support.hpp
@@ -35,7 +35,10 @@ enum language_support {
     support_c99 = support_option_variadics | support_option_long_long | 0x08,
 #endif
 #if BOOST_WAVE_SUPPORT_CPP0X != 0
-    support_cpp0x = support_option_variadics | support_option_long_long | 0x10,
+    support_option_no_newline_at_end_of_file = 0x20,
+
+    support_cpp0x = support_option_variadics | support_option_long_long |
+        support_option_no_newline_at_end_of_file | 0x10,
     support_cpp11 = support_cpp0x,
 #endif
 
@@ -181,24 +184,27 @@ set_support_options(language_support language, language_support option)
     /**/
 
 ///////////////////////////////////////////////////////////////////////////////
-BOOST_WAVE_OPTION(long_long)                // support_option_long_long
-BOOST_WAVE_OPTION(no_character_validation)  // support_option_no_character_validation
-BOOST_WAVE_OPTION(preserve_comments)        // support_option_preserve_comments
-BOOST_WAVE_OPTION(prefer_pp_numbers)        // support_option_prefer_pp_numbers
-BOOST_WAVE_OPTION(emit_line_directives)     // support_option_emit_line_directives
-BOOST_WAVE_OPTION(single_line)              // support_option_single_line
-BOOST_WAVE_OPTION(convert_trigraphs)        // support_option_convert_trigraphs
+BOOST_WAVE_OPTION(long_long)                 // support_option_long_long
+BOOST_WAVE_OPTION(no_character_validation)   // support_option_no_character_validation
+BOOST_WAVE_OPTION(preserve_comments)         // support_option_preserve_comments
+BOOST_WAVE_OPTION(prefer_pp_numbers)         // support_option_prefer_pp_numbers
+BOOST_WAVE_OPTION(emit_line_directives)      // support_option_emit_line_directives
+BOOST_WAVE_OPTION(single_line)               // support_option_single_line
+BOOST_WAVE_OPTION(convert_trigraphs)         // support_option_convert_trigraphs
 #if BOOST_WAVE_SUPPORT_PRAGMA_ONCE != 0
-BOOST_WAVE_OPTION(include_guard_detection)  // support_option_include_guard_detection
+BOOST_WAVE_OPTION(include_guard_detection)   // support_option_include_guard_detection
 #endif
 #if BOOST_WAVE_SUPPORT_VARIADICS_PLACEMARKERS != 0
-BOOST_WAVE_OPTION(variadics)                // support_option_variadics
+BOOST_WAVE_OPTION(variadics)                 // support_option_variadics
 #endif
 #if BOOST_WAVE_EMIT_PRAGMA_DIRECTIVES != 0
-BOOST_WAVE_OPTION(emit_pragma_directives)   // support_option_emit_pragma_directives
+BOOST_WAVE_OPTION(emit_pragma_directives)    // support_option_emit_pragma_directives
 #endif
-BOOST_WAVE_OPTION(insert_whitespace)        // support_option_insert_whitespace
-BOOST_WAVE_OPTION(emit_contnewlines)        // support_option_emit_contnewlines
+BOOST_WAVE_OPTION(insert_whitespace)         // support_option_insert_whitespace
+BOOST_WAVE_OPTION(emit_contnewlines)         // support_option_emit_contnewlines
+#if BOOST_WAVE_SUPPORT_CPP0X != 0
+BOOST_WAVE_OPTION(no_newline_at_end_of_file) // support_no_newline_at_end_of_file
+#endif
 
 #undef BOOST_WAVE_NEED_OPTION
 #undef BOOST_WAVE_ENABLE_OPTION

--- a/test/testwave/testfiles/t_7_001.cpp
+++ b/test/testwave/testfiles/t_7_001.cpp
@@ -8,8 +8,9 @@
 =============================================================================*/
 
 //O --c++11
+//O -Werror
 
-//R #line 16 "t_7_001.cpp"
+//R #line 17 "t_7_001.cpp"
 //R R"de
 //R fg
 //R h"
@@ -17,18 +18,22 @@ R"de
 fg
 h"
 
-//R #line 21 "t_7_001.cpp"
+//R #line 22 "t_7_001.cpp"
 "abc"   //R "abc" 
 R"abc"  //R R"abc" 
 
-//R #line 27 "t_7_001.cpp"
+//R #line 28 "t_7_001.cpp"
 //R uR"de fg
 //R h"
 uR"de \
 fg
 h"
 
-//R #line 32 "t_7_001.cpp"
+//R #line 33 "t_7_001.cpp"
 u"abc"      //R u"abc" 
 U"def"      //R U"def" 
 u8"ghi"     //R u8"ghi" 
+
+//R #line 39 "t_7_001.cpp"
+//R no_newline_at_end_of_file
+no_newline_at_end_of_file

--- a/test/testwave/testwave_app.cpp
+++ b/test/testwave/testwave_app.cpp
@@ -389,6 +389,8 @@ testwave_app::testwave_app(po::variables_map const& vm)
 #if BOOST_WAVE_SUPPORT_CPP0X != 0
         ("c++11", "enable C++11 mode (implies --variadics and --long_long)")
 #endif
+        ("warning,W", po::value<std::vector<std::string> >()->composing(),
+            "Warning settings.")
     ;
 }
 


### PR DESCRIPTION
Remove the warning about the missing new line at the end of the source files in C++11 mode, as it is no longer expected.

This is required to process some of the libcxx headers (and a number of other C++11 and above headers) with Wave without warnings.