### PR TITLE
Add test/Jamfile

### DIFF
--- a/test/Jamfile
+++ b/test/Jamfile
@@ -1,0 +1,3 @@
+import testing ;
+
+build-project build ;


### PR DESCRIPTION
This adds a `Jamfile` in `test` as `wave` is the only library for which `b2 libs/libname/test` doesn't work. This would allow the elimination of the special case at https://github.com/boostorg/boost/blob/master/status/Jamfile.v2#L199.