### PR TITLE
Resolve link errors in MSVC builds by exporting symbols

### DIFF
--- a/include/boost/wave/cpplexer/re2clex/aq.hpp
+++ b/include/boost/wave/cpplexer/re2clex/aq.hpp
@@ -39,10 +39,10 @@ typedef struct tag_aq_queuetype
 
 typedef aq_queuetype* aq_queue;
 
-int aq_enqueue(aq_queue q, aq_stdelement e);
+BOOST_WAVE_DECL int aq_enqueue(aq_queue q, aq_stdelement e);
 int aq_enqueue_front(aq_queue q, aq_stdelement e);
 int aq_serve(aq_queue q, aq_stdelement *e);
-int aq_pop(aq_queue q);
+BOOST_WAVE_DECL int aq_pop(aq_queue q);
 #define AQ_EMPTY(q) (q->size == 0)
 #define AQ_FULL(q) (q->size == q->max_size)
 int aq_grow(aq_queue q);

--- a/include/boost/wave/cpplexer/re2clex/cpp_re.hpp
+++ b/include/boost/wave/cpplexer/re2clex/cpp_re.hpp
@@ -173,7 +173,7 @@ int count_backslash_newlines(Scanner<Iterator> *s, uchar *cursor)
     return skipped;
 }
 
-bool is_backslash(uchar *p, uchar *end, int &len);
+BOOST_WAVE_DECL bool is_backslash(uchar *p, uchar *end, int &len);
 
 #define BOOST_WAVE_BSIZE     196608
 template<typename Iterator>
@@ -350,18 +350,18 @@ uchar *fill(Scanner<Iterator> *s, uchar *cursor)
 //  Special wrapper class holding the current cursor position
 struct uchar_wrapper
 {
-    uchar_wrapper (uchar *base_cursor, std::size_t column = 1);
+    BOOST_WAVE_DECL uchar_wrapper (uchar *base_cursor, std::size_t column = 1);
 
-    uchar_wrapper& operator++();
+    BOOST_WAVE_DECL uchar_wrapper& operator++();
 
-    uchar_wrapper& operator--();
+    BOOST_WAVE_DECL uchar_wrapper& operator--();
 
-    uchar operator* () const;
+    BOOST_WAVE_DECL uchar operator* () const;
 
-    operator uchar *() const;
+    BOOST_WAVE_DECL operator uchar *() const;
 
     friend std::ptrdiff_t
-    operator- (uchar_wrapper const& lhs, uchar_wrapper const& rhs);
+    BOOST_WAVE_DECL operator- (uchar_wrapper const& lhs, uchar_wrapper const& rhs);
 
     uchar *base_cursor;
     std::size_t column;

--- a/include/boost/wave/cpplexer/re2clex/cpp_re.hpp
+++ b/include/boost/wave/cpplexer/re2clex/cpp_re.hpp
@@ -348,20 +348,20 @@ uchar *fill(Scanner<Iterator> *s, uchar *cursor)
 
 ///////////////////////////////////////////////////////////////////////////////
 //  Special wrapper class holding the current cursor position
-struct uchar_wrapper
+struct BOOST_WAVE_DECL uchar_wrapper
 {
-    BOOST_WAVE_DECL uchar_wrapper (uchar *base_cursor, std::size_t column = 1);
+    uchar_wrapper (uchar *base_cursor, std::size_t column = 1);
 
-    BOOST_WAVE_DECL uchar_wrapper& operator++();
+    uchar_wrapper& operator++();
 
-    BOOST_WAVE_DECL uchar_wrapper& operator--();
+    uchar_wrapper& operator--();
 
-    BOOST_WAVE_DECL uchar operator* () const;
+    uchar operator* () const;
 
-    BOOST_WAVE_DECL operator uchar *() const;
+    operator uchar *() const;
 
-    friend std::ptrdiff_t
-    BOOST_WAVE_DECL operator- (uchar_wrapper const& lhs, uchar_wrapper const& rhs);
+    friend BOOST_WAVE_DECL std::ptrdiff_t
+    operator- (uchar_wrapper const& lhs, uchar_wrapper const& rhs);
 
     uchar *base_cursor;
     std::size_t column;


### PR DESCRIPTION
In the forward iterator PR a number of functions became function templates and so moved into .hpp files. As a result some symbols were not locally visible to their users anymore, and now need to be exported for MSVC builds.