### PR TITLE
Force normalized paths to use platform path dividers

### DIFF
--- a/include/boost/wave/util/filesystem_compatibility.hpp
+++ b/include/boost/wave/util/filesystem_compatibility.hpp
@@ -59,7 +59,7 @@ namespace boost { namespace wave { namespace util
 
     inline boost::filesystem::path normalize(boost::filesystem::path& p)
     {
-        return p.normalize();
+        return p.normalize().make_preferred();
     }
 
     inline std::string native_file_string(boost::filesystem::path const& p)


### PR DESCRIPTION
Wave calls `boost::filesystem::normalize()`, which unfortunately can switch to forward slashes for the first (root) component of the path. Path objects have a method `make_preferred()` to force the use of the platform's preferred dividers - backslash, in the case of Windows.  This makes the unit test output comparisons pass (in particular, the three that were failing in MSVC builds).