### PR TITLE
Fixing cpp11 format specs

### DIFF
--- a/include/boost/wave/util/cpp_iterator.hpp
+++ b/include/boost/wave/util/cpp_iterator.hpp
@@ -796,7 +796,7 @@ typename ContextT::position_type pos = act_token.get_position();
 
             if (!ctx.get_hooks().emit_line_directive(ctx, pending, act_token))
             {
-            unsigned int column = 6;
+                unsigned int column = 6;
 
                 // the hook did not generate anything, emit default #line
                 pos.set_column(1);
@@ -805,10 +805,10 @@ typename ContextT::position_type pos = act_token.get_position();
                 pos.set_column(column);      // account for '#line'
                 pending.push_back(result_type(T_SPACE, " ", pos));
 
-            // 21 is the max required size for a 64 bit integer represented as a
-            // string
+                // 21 is the max required size for a 64 bit integer represented as a
+                // string
 
-		std::string buffer = lexical_cast<std::string>(pos.get_line());
+                std::string buffer = lexical_cast<std::string>(pos.get_line());
 
                 pos.set_column(++column);                 // account for ' '
                 pending.push_back(result_type(T_INTLIT, buffer.c_str(), pos));
@@ -816,9 +816,9 @@ typename ContextT::position_type pos = act_token.get_position();
                 pending.push_back(result_type(T_SPACE, " ", pos));
                 pos.set_column(++column);                 // account for ' '
 
-            std::string file("\"");
-            boost::filesystem::path filename(
-                wave::util::create_path(act_pos.get_file().c_str()));
+                std::string file("\"");
+                boost::filesystem::path filename(
+                    wave::util::create_path(act_pos.get_file().c_str()));
 
                 using wave::util::impl::escape_lit;
                 file += escape_lit(wave::util::native_file_string(filename)) + "\"";

--- a/include/boost/wave/util/cpp_iterator.hpp
+++ b/include/boost/wave/util/cpp_iterator.hpp
@@ -23,6 +23,7 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
+#include <boost/lexical_cast.hpp>
 #include <boost/spirit/include/classic_multi_pass.hpp>
 #include <boost/spirit/include/classic_parse_tree_utils.hpp>
 
@@ -806,14 +807,12 @@ typename ContextT::position_type pos = act_token.get_position();
 
             // 21 is the max required size for a 64 bit integer represented as a
             // string
-            char buffer[22];
 
-                using namespace std;    // for some systems sprintf is in namespace std
-                sprintf (buffer, "%zd", pos.get_line());
+		std::string buffer = lexical_cast<std::string>(pos.get_line());
 
                 pos.set_column(++column);                 // account for ' '
-                pending.push_back(result_type(T_INTLIT, buffer, pos));
-                pos.set_column(column += (unsigned int)strlen(buffer)); // account for <number>
+                pending.push_back(result_type(T_INTLIT, buffer.c_str(), pos));
+                pos.set_column(column += buffer.size()); // account for <number>
                 pending.push_back(result_type(T_SPACE, " ", pos));
                 pos.set_column(++column);                 // account for ' '
 

--- a/include/boost/wave/util/cpp_macromap.hpp
+++ b/include/boost/wave/util/cpp_macromap.hpp
@@ -32,6 +32,7 @@
 #endif
 
 #include <boost/filesystem/path.hpp>
+#include <boost/lexical_cast.hpp>
 
 #include <boost/wave/util/time_conversion_helper.hpp>
 #include <boost/wave/util/unput_queue_iterator.hpp>
@@ -1411,11 +1412,9 @@ string_type const &value = curr_token.get_value();
 
     if (value == "__LINE__") {
     // expand the __LINE__ macro
-    char buffer[22];    // 21 bytes holds all NUL-terminated unsigned 64-bit numbers
+        std::string buffer = lexical_cast<std::string>(main_pos.get_line());
 
-        using namespace std;    // for some systems sprintf is in namespace std
-        sprintf(buffer, "%zd", main_pos.get_line());
-        expanded.push_back(token_type(T_INTLIT, buffer, curr_token.get_position()));
+        expanded.push_back(token_type(T_INTLIT, buffer.c_str(), curr_token.get_position()));
         return true;
     }
     else if (value == "__FILE__") {


### PR DESCRIPTION
Wave uses the "%zd" format spec in a couple of places.  Unfortunately, the "z" modifier was introduced in C+11 and so it does not work with old versions of MSVC.  This commit replaces `sprintf` with `boost::lexical_cast`.