### PR TITLE
Unbreak build on FreeBSD after e941cb580649

### DIFF
--- a/include/boost/wave/cpplexer/re2clex/cpp_re.hpp
+++ b/include/boost/wave/cpplexer/re2clex/cpp_re.hpp
@@ -373,6 +373,9 @@ boost::wave::token_id scan(Scanner<Iterator> *s)
     string_type   rawstringdelim;         // for use with C++11 raw string literals
 
 // include the correct Re2C token definition rules
+#if (defined (__FreeBSD__) || defined (__DragonFly__) || defined (__OpenBSD__)) && defined (T_DIVIDE)
+#undef T_DIVIDE
+#endif
 #if BOOST_WAVE_USE_STRICT_LEXER != 0
 #include "strict_cpp_re.inc"
 #else


### PR DESCRIPTION
Wrong `T_DIVIDE` is bootlegged. Let's undefine it similar to https://github.com/boostorg/wave/blob/6ca4f8229d1128392b2b27c829b12af5b5f3387c/include/boost/wave/token_ids.hpp#L30-L32
```
In file included from libs/wave/src/instantiate_re2c_lexer.cpp:29:
In file included from ./boost/wave/cpplexer/re2clex/cpp_re2c_lexer.hpp:25:
In file included from ./boost/spirit/include/classic_core.hpp:11:
In file included from ./boost/spirit/home/classic/core.hpp:42:
In file included from ./boost/spirit/home/classic/core/non_terminal/grammar.hpp:21:
In file included from ./boost/spirit/home/classic/core/non_terminal/impl/grammar.ipp:15:
In file included from ./boost/spirit/home/classic/core/non_terminal/impl/object_with_id.ipp:14:
In file included from ./boost/shared_ptr.hpp:17:
In file included from ./boost/smart_ptr/shared_ptr.hpp:36:
In file included from ./boost/smart_ptr/detail/spinlock_pool.hpp:25:
In file included from ./boost/smart_ptr/detail/spinlock.hpp:47:
In file included from ./boost/smart_ptr/detail/spinlock_std_atomic.hpp:18:
In file included from ./boost/smart_ptr/detail/yield_k.hpp:28:
In file included from ./boost/predef.h:17:
In file included from ./boost/predef/os.h:18:
In file included from ./boost/predef/os/bsd.h:52:
In file included from ./boost/predef/os/bsd/bsdi.h:11:
In file included from ./boost/predef/os/bsd.h:95:
In file included from ./boost/predef/os/bsd/dragonfly.h:11:
In file included from ./boost/predef/os/bsd.h:96:
In file included from ./boost/predef/os/bsd/free.h:37:
In file included from /usr/include/sys/param.h:134:
In file included from /usr/include/sys/signal.h:46:
In file included from /usr/include/machine/signal.h:6:
In file included from /usr/include/x86/signal.h:45:
In file included from /usr/include/machine/trap.h:6:
/usr/include/x86/trap.h:52:2: error: wrong T_DIVIDE inherited, aborting
```
