### PR TITLE
use boost filesystem streams for opening files in wave

### DIFF
--- a/include/boost/wave/cpp_iteration_context.hpp
+++ b/include/boost/wave/cpp_iteration_context.hpp
@@ -13,7 +13,7 @@
 #define CPP_ITERATION_CONTEXT_HPP_00312288_9DDB_4668_AFE5_25D3994FD095_INCLUDED
 
 #include <iterator>
-#include <fstream>
+#include <boost/filesystem/fstream.hpp>
 #if defined(BOOST_NO_TEMPLATED_ITERATOR_CONSTRUCTORS)
 #include <sstream>
 #endif
@@ -64,7 +64,7 @@ namespace iteration_context_policies {
                 typedef typename IterContextT::iterator_type iterator_type;
 
                 // read in the file
-                std::ifstream instream(iter_ctx.filename.c_str());
+                boost::filesystem::ifstream instream(iter_ctx.filename.c_str());
                 if (!instream.is_open()) {
                     BOOST_WAVE_THROW_CTX(iter_ctx.ctx, preprocess_exception,
                         bad_include_file, iter_ctx.filename.c_str(), act_pos);

--- a/tool/cpp.cpp
+++ b/tool/cpp.cpp
@@ -18,6 +18,7 @@
 // Include additional Boost libraries
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/convenience.hpp>
+#include <boost/filesystem/fstream.hpp>
 #include <boost/timer.hpp>
 #include <boost/any.hpp>
 #include <boost/algorithm/cxx11/any_of.hpp>
@@ -86,7 +87,8 @@ using namespace boost::spirit::classic;
 using std::pair;
 using std::vector;
 using std::getline;
-using std::ofstream;
+using boost::filesystem::ofstream;
+using boost::filesystem::ifstream;
 using std::cout;
 using std::cerr;
 using std::endl;
@@ -229,7 +231,7 @@ namespace cmd_line_utils {
         po::options_description const &desc, po::variables_map &vm,
         bool may_fail = false)
     {
-    std::ifstream ifs(filename.c_str());
+        ifstream ifs(filename.c_str());
 
         if (!ifs.is_open()) {
             if (!may_fail) {
@@ -468,7 +470,7 @@ namespace {
 #if BOOST_WAVE_BINARY_SERIALIZATION != 0
                 mode = (std::ios::openmode)(mode | std::ios::binary);
 #endif
-                std::ifstream ifs (state_file.string().c_str(), mode);
+                ifstream ifs (state_file.string().c_str(), mode);
                 if (ifs.is_open()) {
                     using namespace boost::serialization;
                     iarchive ia(ifs);
@@ -540,7 +542,7 @@ namespace {
     bool list_macro_names(context_type const& ctx, std::string filename)
     {
     // open file for macro names listing
-        std::ofstream macronames_out;
+        ofstream macronames_out;
         fs::path macronames_file (boost::wave::util::create_path(filename));
 
         if (macronames_file != "-") {
@@ -610,7 +612,7 @@ namespace {
     bool list_macro_counts(context_type const& ctx, std::string filename)
     {
     // open file for macro invocation count listing
-        std::ofstream macrocounts_out;
+        ofstream macrocounts_out;
         fs::path macrocounts_file (boost::wave::util::create_path(filename));
 
         if (macrocounts_file != "-") {
@@ -687,10 +689,10 @@ const bool treat_warnings_as_error = vm.count("warning") &&
 
     // The preprocessing of the input stream is done on the fly behind the
     // scenes during iteration over the context_type::iterator_type stream.
-    std::ofstream output;
-    std::ofstream traceout;
-    std::ofstream includelistout;
-    std::ofstream listguardsout;
+    ofstream output;
+    ofstream traceout;
+    ofstream includelistout;
+    ofstream listguardsout;
 
     trace_flags enable_trace = trace_nothing;
 
@@ -829,7 +831,7 @@ const bool treat_warnings_as_error = vm.count("warning") &&
         if (vm.count ("license")) {
         // try to open the file, where to put the preprocessed output
         std::string license_file(vm["license"].as<std::string>());
-        std::ifstream license_stream(license_file.c_str());
+        ifstream license_stream(license_file.c_str());
 
             if (!license_stream.is_open()) {
                 cerr << "wave: could not open specified license file: "
@@ -1484,7 +1486,7 @@ main (int argc, char *argv[])
             }
 
         std::string file_name(arguments[0].value[0]);
-        std::ifstream instream(file_name.c_str());
+        ifstream instream(file_name.c_str());
 
         // preprocess the given input file
             if (!instream.is_open()) {

--- a/tool/cpp.cpp
+++ b/tool/cpp.cpp
@@ -19,6 +19,7 @@
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/convenience.hpp>
 #include <boost/filesystem/fstream.hpp>
+#include <boost/filesystem/detail/utf8_codecvt_facet.hpp>
 #include <boost/timer.hpp>
 #include <boost/any.hpp>
 #include <boost/algorithm/cxx11/any_of.hpp>
@@ -1256,6 +1257,11 @@ const bool treat_warnings_as_error = vm.count("warning") &&
 int
 main (int argc, char *argv[])
 {
+    std::locale global_loc = std::locale();
+    std::locale loc(global_loc, new
+                    boost::filesystem::detail::utf8_codecvt_facet);
+    boost::filesystem::path::imbue(loc);
+
     const std::string accepted_w_args[] = {"error"};
 
     // test Wave compilation configuration

--- a/tool/cpp.hpp
+++ b/tool/cpp.hpp
@@ -17,7 +17,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 //  include often used files from the stdlib
 #include <iostream>
-#include <fstream>
 #include <string>
 #include <vector>
 #include <algorithm>


### PR DESCRIPTION
This is the PR for issue #32.
The first commit changes standard streams to boost streams in the wave lib and the wave driver. I left out the samples.
The second submit is a demo on how to switch the wave driver to UTF-8 paths. I had no luck passing UTF-8 arguments to wave using cmd.exe, you have to switch to mintty or something. But all invocations of wave without passing in UTF-8 paths work. I'd rather not pull the second submit as-is, maybe the locale switch should be optional or left away altogether. I would be happy if the first commit made it into boost wave. 