### PR TITLE
Fixed usage of auto_ptr on systems where it is deprecated

### DIFF
--- a/samples/cpp_tokens/slex/lexer.hpp
+++ b/samples/cpp_tokens/slex/lexer.hpp
@@ -40,6 +40,7 @@
 #define BOOST_SPIRIT_LEXER_HPP
 
 ///////////////////////////////////////////////////////////////////////////////
+#include <boost/config.hpp>
 #include <boost/throw_exception.hpp>
 
 #include <boost/spirit/include/classic_core.hpp>
@@ -49,6 +50,7 @@
 
 #include <set>
 #include <map>
+#include <memory> // for auto_ptr/unique_ptr
 #include <vector>
 #include <stack>
 #include <utility> // for pair
@@ -355,7 +357,7 @@ public:
 
 private:
 
-#ifdef BOOST_NO_AUTO_PTR
+#ifndef BOOST_NO_CXX11_SMART_PTR
     std::unique_ptr<node> m_left;
     std::unique_ptr<node> m_right;
 #else
@@ -488,7 +490,7 @@ public:
 
 private:
 
-#ifdef BOOST_NO_AUTO_PTR
+#ifndef BOOST_NO_CXX11_SMART_PTR
     std::unique_ptr<node> m_left;
     std::unique_ptr<node> m_right;
 #else
@@ -644,7 +646,7 @@ public:
 
 private:
 
-#ifdef BOOST_NO_AUTO_PTR
+#ifndef BOOST_NO_CXX11_SMART_PTR
     std::unique_ptr<node> m_left;
 #else
     std::auto_ptr<node> m_left;
@@ -2417,7 +2419,7 @@ bool find_acceptance_state(const node_set& eof_node_ids,
 }
 
 template <typename RegexListT, typename GrammarT>
-#ifdef BOOST_NO_AUTO_PTR
+#ifndef BOOST_NO_CXX11_SMART_PTR
 inline std::unique_ptr<node>
 #else
 inline std::auto_ptr<node>
@@ -2429,7 +2431,7 @@ parse_regexes(const RegexListT& regex_list, GrammarT& g)
         boost::throw_exception(bad_regex());
 
     typename RegexListT::const_iterator ri = regex_list.begin();
-#ifdef BOOST_NO_AUTO_PTR
+#ifndef BOOST_NO_CXX11_SMART_PTR
     std::unique_ptr<node> tree(lexerimpl::parse(g, (*ri).str));
 #else
     std::auto_ptr<node> tree(lexerimpl::parse(g, (*ri).str));
@@ -2440,14 +2442,14 @@ parse_regexes(const RegexListT& regex_list, GrammarT& g)
     ++ri;
     for (/**/; ri != regex_list.end(); ++ri)
     {
-#ifdef BOOST_NO_AUTO_PTR
+#ifndef BOOST_NO_CXX11_SMART_PTR
         std::unique_ptr<node> next_tree(lexerimpl::parse(g, (*ri).str));
 #else
         std::auto_ptr<node> next_tree(lexerimpl::parse(g, (*ri).str));
 #endif
         if (next_tree.get() == 0)
             boost::throw_exception(bad_regex());
-#ifdef BOOST_NO_AUTO_PTR
+#ifndef BOOST_NO_CXX11_SMART_PTR
         tree = std::unique_ptr<node>(new or_node(tree.release(), next_tree.release()));
 #else
         tree = std::auto_ptr<node>(new or_node(tree.release(), next_tree.release()));
@@ -2473,7 +2475,7 @@ inline void
 lexer<IteratorT, TokenT, CallbackT>::create_dfa_for_state(int state)
 {
     using lexerimpl::node;
-#ifdef BOOST_NO_AUTO_PTR
+#ifndef BOOST_NO_CXX11_SMART_PTR
     std::unique_ptr<node> tree = lexerimpl::parse_regexes(m_regex_list[state], g);
 #else
     std::auto_ptr<node> tree = lexerimpl::parse_regexes(m_regex_list[state], g);


### PR DESCRIPTION
The macro `BOOST_NO_AUTO_PTR` is defined on systems where both `auto_ptr` and
`unique_ptr` are available (and `auto_ptr` usage produces a deprecation warning).
By using `BOOST_NO_CXX11_SMART_PTR` we will favor `unique_ptr` over `auto_ptr`.

```
slex/lexer.hpp:2423:13: error: 'template<class> class std::auto_ptr' is deprecated [-Werror=deprecated-declarations]
```