### PR TITLE
fix utf8 testcases on non-windows systems

### DIFF
--- a/test/testwave/testfiles/t_9_025.cpp
+++ b/test/testwave/testfiles/t_9_025.cpp
@@ -9,5 +9,5 @@
 
 //U yes
 //R #line 10 "file.hpp"
-//R "$P(utf8-test-ßµ™∃\\file.hpp)"
+//R "$P(utf8-test-ßµ™∃/file.hpp)"
 #include <utf8-test-ßµ™∃/file.hpp>

--- a/test/testwave/testfiles/t_9_026.cpp
+++ b/test/testwave/testfiles/t_9_026.cpp
@@ -10,5 +10,5 @@
 //U yes
 //O -S$P(utf8-test-ßµ™∃)
 //R #line 10 "file.hpp"
-//R "$P(utf8-test-ßµ™∃\\file.hpp)"
+//R "$P(utf8-test-ßµ™∃/file.hpp)"
 #include <file.hpp>

--- a/test/testwave/testfiles/test.cfg
+++ b/test/testwave/testfiles/test.cfg
@@ -247,5 +247,5 @@ t_9_023.cpp
 t_9_024.cpp
 t_9_025.cpp
 t_9_026.cpp
-t_9_027.cpp
-t_9_028.cpp
+# t_9_027.cpp currently disabled, expected fail only on windows
+# t_9_028.cpp currently disabled, expected fail only on windows


### PR DESCRIPTION
The failures t_9_025 and t_9_026 were caused by me using backslashes in the expected results. By using forward slashes the result check should work on all systems.  The failures of t_9_027 and t_9_028 are system-specific -- we cannot expect these tests to fail on systems that already use UTF-8 for path encoding. To be honest, these tests were just a check for me that the new /U yes path imbue switch was just local to a single test and didn't mess up other tests and they can be used for demonstration purposes that you have to switch to UTF8 path conversions on Windows. t_9_025 and t_9_026 alone are able to show that you can now open includes with UTF-8 encoded paths on all systems. I think t_9_027 and t_9_028 can be left out of the full test suite so i disabled  them in test.cfg.