### PR TITLE
Add BOOST_SYMBOL_VISIBLE to explicit instantiations, to fix link errors on Linux/Mac

### DIFF
--- a/include/boost/wave/cpplexer/re2clex/cpp_re2c_lexer.hpp
+++ b/include/boost/wave/cpplexer/re2clex/cpp_re2c_lexer.hpp
@@ -375,7 +375,7 @@ token_cache<typename lexer<IteratorT, PositionT, TokenT>::string_type> const
 ///////////////////////////////////////////////////////////////////////////////
 
 #if BOOST_WAVE_SEPARATE_LEXER_INSTANTIATION != 0
-#define BOOST_WAVE_RE2C_NEW_LEXER_INLINE BOOST_SYMBOL_VISIBLE
+#define BOOST_WAVE_RE2C_NEW_LEXER_INLINE
 #else
 #define BOOST_WAVE_RE2C_NEW_LEXER_INLINE inline
 #endif

--- a/include/boost/wave/cpplexer/re2clex/cpp_re2c_lexer.hpp
+++ b/include/boost/wave/cpplexer/re2clex/cpp_re2c_lexer.hpp
@@ -375,7 +375,7 @@ token_cache<typename lexer<IteratorT, PositionT, TokenT>::string_type> const
 ///////////////////////////////////////////////////////////////////////////////
 
 #if BOOST_WAVE_SEPARATE_LEXER_INSTANTIATION != 0
-#define BOOST_WAVE_RE2C_NEW_LEXER_INLINE
+#define BOOST_WAVE_RE2C_NEW_LEXER_INLINE BOOST_SYMBOL_VISIBLE
 #else
 #define BOOST_WAVE_RE2C_NEW_LEXER_INLINE inline
 #endif

--- a/src/instantiate_cpp_exprgrammar.cpp
+++ b/src/instantiate_cpp_exprgrammar.cpp
@@ -41,7 +41,7 @@
 typedef boost::wave::cpplexer::lex_token<> token_type;
 
 // no need to change anything below
-template struct boost::wave::grammars::expression_grammar_gen<token_type>;
+template struct BOOST_SYMBOL_VISIBLE boost::wave::grammars::expression_grammar_gen<token_type>;
 
 // the suffix header occurs after all of the code
 #ifdef BOOST_HAS_ABI_HEADERS

--- a/src/instantiate_cpp_grammar.cpp
+++ b/src/instantiate_cpp_grammar.cpp
@@ -45,7 +45,7 @@ typedef boost::wave::cpplexer::lex_iterator<token_type> lexer_type;
 typedef std::list<token_type, boost::fast_pool_allocator<token_type> >
     token_sequence_type;
 
-template struct boost::wave::grammars::cpp_grammar_gen<lexer_type, token_sequence_type>;
+template struct BOOST_SYMBOL_VISIBLE boost::wave::grammars::cpp_grammar_gen<lexer_type, token_sequence_type>;
 
 // the suffix header occurs after all of the code
 #ifdef BOOST_HAS_ABI_HEADERS

--- a/src/instantiate_cpp_literalgrs.cpp
+++ b/src/instantiate_cpp_literalgrs.cpp
@@ -43,9 +43,9 @@ typedef boost::wave::cpplexer::lex_token<> token_type;
 template struct boost::wave::grammars::intlit_grammar_gen<token_type>;
 #if BOOST_WAVE_WCHAR_T_SIGNEDNESS == BOOST_WAVE_WCHAR_T_AUTOSELECT || \
     BOOST_WAVE_WCHAR_T_SIGNEDNESS == BOOST_WAVE_WCHAR_T_FORCE_SIGNED
-template struct boost::wave::grammars::chlit_grammar_gen<int, token_type>;
+template struct BOOST_SYMBOL_VISIBLE boost::wave::grammars::chlit_grammar_gen<int, token_type>;
 #endif
-template struct boost::wave::grammars::chlit_grammar_gen<unsigned int, token_type>;
+template struct BOOST_SYMBOL_VISIBLE boost::wave::grammars::chlit_grammar_gen<unsigned int, token_type>;
 
 // the suffix header occurs after all of the code
 #ifdef BOOST_HAS_ABI_HEADERS

--- a/src/instantiate_defined_grammar.cpp
+++ b/src/instantiate_defined_grammar.cpp
@@ -41,7 +41,7 @@ typedef boost::wave::cpplexer::lex_token<> token_type;
 
 // no need to change anything below
 typedef boost::wave::cpplexer::lex_iterator<token_type> lexer_type;
-template struct boost::wave::grammars::defined_grammar_gen<lexer_type>;
+template struct BOOST_SYMBOL_VISIBLE boost::wave::grammars::defined_grammar_gen<lexer_type>;
 
 // the suffix header occurs after all of the code
 #ifdef BOOST_HAS_ABI_HEADERS

--- a/src/instantiate_predef_macros.cpp
+++ b/src/instantiate_predef_macros.cpp
@@ -41,7 +41,7 @@ typedef boost::wave::cpplexer::lex_token<> token_type;
 
 // no need to change anything below
 typedef boost::wave::cpplexer::lex_iterator<token_type> lexer_type;
-template struct boost::wave::grammars::predefined_macros_grammar_gen<lexer_type>;
+template struct BOOST_SYMBOL_VISIBLE boost::wave::grammars::predefined_macros_grammar_gen<lexer_type>;
 
 // the suffix header occurs after all of the code
 #ifdef BOOST_HAS_ABI_HEADERS

--- a/src/instantiate_re2c_lexer.cpp
+++ b/src/instantiate_re2c_lexer.cpp
@@ -52,9 +52,9 @@
 
 // if you want to use another iterator type for the underlying input stream
 // a corresponding explicit template instantiation needs to be added below
-template struct boost::wave::cpplexer::new_lexer_gen<
+template struct BOOST_SYMBOL_VISIBLE boost::wave::cpplexer::new_lexer_gen<
     BOOST_WAVE_STRINGTYPE::iterator>;
-template struct boost::wave::cpplexer::new_lexer_gen<
+template struct BOOST_SYMBOL_VISIBLE boost::wave::cpplexer::new_lexer_gen<
     BOOST_WAVE_STRINGTYPE::const_iterator>;
 
 // the suffix header occurs after all of the code

--- a/src/instantiate_re2c_lexer_str.cpp
+++ b/src/instantiate_re2c_lexer_str.cpp
@@ -52,8 +52,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #if !defined(BOOST_WAVE_STRINGTYPE_USE_STDSTRING)
-template struct boost::wave::cpplexer::new_lexer_gen<std::string::iterator>;
-template struct boost::wave::cpplexer::new_lexer_gen<std::string::const_iterator>;
+template struct BOOST_SYMBOL_VISIBLE boost::wave::cpplexer::new_lexer_gen<std::string::iterator>;
+template struct BOOST_SYMBOL_VISIBLE boost::wave::cpplexer::new_lexer_gen<std::string::const_iterator>;
 #endif
 
 // the suffix header occurs after all of the code

--- a/test/build/Jamfile.v2
+++ b/test/build/Jamfile.v2
@@ -165,5 +165,13 @@ test-suite wave
                 test_re2c_lexer
         ]
 
+        [
+            run
+            # sources
+                ../testwave/quick.cpp
+                /boost/wave//boost_wave
+                /boost/thread//boost_thread
+                /boost/filesystem//boost_filesystem
+        ]
     ;
 

--- a/test/testwave/quick.cpp
+++ b/test/testwave/quick.cpp
@@ -1,0 +1,49 @@
+
+// Copyright 2018 Peter Dimov.
+//
+// Distributed under the Boost Software License, Version 1.0.
+//
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/wave.hpp>
+#include <boost/wave/cpplexer/cpp_lex_token.hpp>
+#include <boost/wave/cpplexer/cpp_lex_iterator.hpp>
+#include <iostream>
+
+int main()
+{
+    std::string input(
+        "#if 0\n"
+        "6.28\n"
+        "#else\n"
+        "3.14\n"
+        "#endif\n"
+    );
+
+    try
+    {
+        typedef boost::wave::cpplexer::lex_token<> token_type;
+        typedef boost::wave::cpplexer::lex_iterator<token_type> lex_iterator_type;
+        typedef boost::wave::context<std::string::iterator, lex_iterator_type> context_type;
+
+        context_type ctx( input.begin(), input.end(), "input.cpp" );
+
+        for( context_type::iterator_type first = ctx.begin(), last = ctx.end(); first != last; ++first )
+        {
+            std::cout << first->get_value();
+        }
+
+        return 0;
+    }
+    catch( boost::wave::cpp_exception const & x )
+    {
+        std::cerr << x.file_name() << "(" << x.line_no() << "): " << x.description() << std::endl;
+        return 1;
+    }
+    catch( std::exception const & x )
+    {
+        std::cerr << "Exception: " << x.what() << std::endl;
+        return 2;
+    }
+}


### PR DESCRIPTION
Fixes #41.