### PR TITLE
Link against Boost.Filesystem to resolve missing symbols in samples

### DIFF
--- a/samples/advanced_hooks/build/Jamfile.v2
+++ b/samples/advanced_hooks/build/Jamfile.v2
@@ -13,5 +13,6 @@ exe advanced_hooks
         /boost/wave//boost_wave
         /boost/thread//boost_thread
         /boost/date_time//boost_date_time
+        /boost/filesystem//boost_filesystem
     ;  
 

--- a/samples/custom_directives/build/Jamfile.v2
+++ b/samples/custom_directives/build/Jamfile.v2
@@ -13,5 +13,6 @@ exe custom_directives
         /boost/wave//boost_wave
         /boost/thread//boost_thread
         /boost/date_time//boost_date_time
+        /boost/filesystem//boost_filesystem
     ;  
 

--- a/samples/emit_custom_line_directives/build/Jamfile.v2
+++ b/samples/emit_custom_line_directives/build/Jamfile.v2
@@ -13,5 +13,6 @@ exe emit_custom_line_directives
         /boost/wave//boost_wave
         /boost/thread//boost_thread
         /boost/date_time//boost_date_time
+        /boost/filesystem//boost_filesystem
     ;  
 

--- a/samples/quick_start/build/Jamfile.v2
+++ b/samples/quick_start/build/Jamfile.v2
@@ -14,5 +14,6 @@ exe quick_start
         /boost/system//boost_system
         /boost/thread//boost_thread
         /boost/date_time//boost_date_time
+        /boost/filesystem//boost_filesystem
     ;  
 


### PR DESCRIPTION
I noticed several samples would fail at the link stage, all with missing Boost.Filesystem symbols. I couldn't find a way to have them inlined so I assume this changed at some point. Adding FS explicitly fixes it.