### PR TITLE
Instantiate lexers with std::string, not flex_string

### DIFF
--- a/samples/list_includes/instantiate_lexertl_lexer.cpp
+++ b/samples/list_includes/instantiate_lexertl_lexer.cpp
@@ -39,6 +39,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 template struct boost::wave::cpplexer::lexertl::new_lexer_gen<
-    BOOST_WAVE_STRINGTYPE::iterator>;
+    std::string::iterator>;
 
 #endif // BOOST_WAVE_SEPARATE_LEXER_INSTANTIATION != 0

--- a/samples/real_positions/instantiate_re2c_lexer.cpp
+++ b/samples/real_positions/instantiate_re2c_lexer.cpp
@@ -48,10 +48,10 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 template struct boost::wave::cpplexer::new_lexer_gen<
-    BOOST_WAVE_STRINGTYPE::iterator, boost::wave::util::file_position_type,
+    std::string::iterator, boost::wave::util::file_position_type,
     lex_token<boost::wave::util::file_position_type> >;
 template struct boost::wave::cpplexer::new_lexer_gen<
-    BOOST_WAVE_STRINGTYPE::const_iterator, boost::wave::util::file_position_type,
+    std::string::const_iterator, boost::wave::util::file_position_type,
     lex_token<boost::wave::util::file_position_type> >;
 
 // the suffix header occurs after all of the code


### PR DESCRIPTION
Two samples fail at the link stage looking for a different `new_lexer_gen<>::new_lexer()` than we provide.

AFAICT the type of the lexer is dependent on what string was used to construct the wave context object and that propagates down. Updating these files fixes the error.