### PR TITLE
Fix the problem where disabling `include_next` support breaks regular `include`.

### DIFF
--- a/include/boost/wave/cpplexer/re2clex/cpp_re2c_lexer.hpp
+++ b/include/boost/wave/cpplexer/re2clex/cpp_re2c_lexer.hpp
@@ -196,7 +196,6 @@ lexer<IteratorT, PositionT, TokenT>::get(TokenT& result)
             impl::validate_literal(value, actline, scanner.column, filename);
         break;
 
-#if BOOST_WAVE_SUPPORT_INCLUDE_NEXT != 0
     case T_PP_HHEADER:
     case T_PP_QHEADER:
     case T_PP_INCLUDE:
@@ -205,13 +204,14 @@ lexer<IteratorT, PositionT, TokenT>::get(TokenT& result)
           value = string_type((char const *)scanner.tok,
               scanner.cur-scanner.tok);
 
+#if BOOST_WAVE_SUPPORT_INCLUDE_NEXT != 0
       // Skip '#' and whitespace and see whether we find an 'include_next' here.
           typename string_type::size_type start = value.find("include");
           if (value.compare(start, 12, "include_next", 12) == 0)
               id = token_id(id | AltTokenType);
+#endif
           break;
       }
-#endif
 
     case T_LONGINTLIT:  // supported in C++11, C99 and long_long mode
         value = string_type((char const *)scanner.tok,

--- a/samples/cpp_tokens/slex/cpp_slex_lexer.hpp
+++ b/samples/cpp_tokens/slex/cpp_slex_lexer.hpp
@@ -687,20 +687,20 @@ public:
                         }
                         break;
 
-#if BOOST_WAVE_SUPPORT_INCLUDE_NEXT != 0
                     case T_PP_HHEADER:
                     case T_PP_QHEADER:
                     case T_PP_INCLUDE:
                     // convert to the corresponding ..._next token, if appropriate
                         {
+#if BOOST_WAVE_SUPPORT_INCLUDE_NEXT != 0
                         // Skip '#' and whitespace and see whether we find an
                         // 'include_next' here.
                             typename string_type::size_type start = value.find("include");
                             if (0 == value.compare(start, 12, "include_next", 12))
                                 id = token_id(id | AltTokenType);
+#endif // BOOST_WAVE_SUPPORT_INCLUDE_NEXT != 0
                             break;
                         }
-#endif // BOOST_WAVE_SUPPORT_INCLUDE_NEXT != 0
 
                     case T_EOF:
                     // T_EOF is returned as a valid token, the next call will

--- a/samples/list_includes/lexertl/lexertl_lexer.hpp
+++ b/samples/list_includes/lexertl/lexertl_lexer.hpp
@@ -651,11 +651,11 @@ public:
                         }
                         break;
 
-#if BOOST_WAVE_SUPPORT_INCLUDE_NEXT != 0
                     case T_PP_HHEADER:
                     case T_PP_QHEADER:
                     case T_PP_INCLUDE:
                     // convert to the corresponding ..._next token, if appropriate
+#if BOOST_WAVE_SUPPORT_INCLUDE_NEXT != 0
                         {
                         // Skip '#' and whitespace and see whether we find an
                         // 'include_next' here.
@@ -663,8 +663,8 @@ public:
                             if (0 == token_val.compare(start, 12, "include_next", 12))
                                 id = token_id(id | AltTokenType);
                         }
-                        break;
 #endif // BOOST_WAVE_SUPPORT_INCLUDE_NEXT != 0
+                        break;
 
                     case T_EOF:
                     // T_EOF is returned as a valid token, the next call will


### PR DESCRIPTION
It applies the same fix suggested by the original poster of #54 and if merged will resolve it.