### PR TITLE
Restore waveidl sample to working condition

### DIFF
--- a/samples/waveidl/idllexer/idl_lex_iterator.hpp
+++ b/samples/waveidl/idllexer/idl_lex_iterator.hpp
@@ -173,7 +173,7 @@ public:
     :   base_type(
             functor_data_type(
                 unique_functor_type(),
-                cpplexer::lex_input_interface_generator<TokenT>
+                idllexer::lex_input_interface_generator<TokenT>
                     ::new_lexer(first, last, pos, language)
             )
         )

--- a/samples/waveidl/idllexer/idl_re2c_lexer.hpp
+++ b/samples/waveidl/idllexer/idl_re2c_lexer.hpp
@@ -116,7 +116,6 @@ template <typename IteratorT, typename PositionT>
 inline
 lexer<IteratorT, PositionT>::~lexer() 
 {
-    boost::wave::cpplexer::re2clex::aq_terminate(scanner.eol_offsets);
     free(scanner.bot);
 }
 


### PR DESCRIPTION
- use the idllexer generator instead of the cpp one
- eliminate a double free encountered during fix

If merged, this will resolve #56