### PR TITLE
Fix compilation issue caused by std::allocator member removal in C++20

### DIFF
--- a/include/boost/wave/util/flex_string.hpp
+++ b/include/boost/wave/util/flex_string.hpp
@@ -549,8 +549,13 @@ class AllocatorStringStorage : public A
 
     void* Alloc(size_type sz, const void* p = 0)
     {
+#if defined(BOOST_NO_CXX11_ALLOCATOR)
         return A::allocate(1 + (sz - 1) / sizeof(E),
             static_cast<const char*>(p));
+#else
+        return std::allocator_traits<A>::allocate(*this, 1 + (sz - 1) / sizeof(E),
+            static_cast<const char*>(p));
+#endif
     }
 
     void* Realloc(void* p, size_type oldSz, size_type newSz)
@@ -666,7 +671,11 @@ public:
     { return size_type(end() - begin()); }
 
     size_type max_size() const
+#if defined(BOOST_NO_CXX11_ALLOCATOR)
     { return A::max_size(); }
+#else
+    { return std::allocator_traits<A>::max_size(*this); }
+#endif
 
     size_type capacity() const
     { return size_type(pData_->pEndOfMem_ - pData_->buffer_); }
@@ -1202,7 +1211,7 @@ public:
     typedef typename Storage::const_iterator const_iterator;
     typedef typename Storage::allocator_type allocator_type;
     typedef typename allocator_type::size_type size_type;
-    typedef typename Storage::reference reference;
+    typedef typename Storage::value_type& reference;
 
 private:
     union
@@ -1464,10 +1473,17 @@ public:
     typedef typename A::size_type size_type;
     typedef typename A::difference_type difference_type;
 
+#if defined(BOOST_NO_CXX11_ALLOCATOR)
     typedef typename A::reference reference;
     typedef typename A::const_reference const_reference;
     typedef typename A::pointer pointer;
     typedef typename A::const_pointer const_pointer;
+#else
+    typedef typename std::allocator_traits<A>::value_type& reference;
+    typedef typename std::allocator_traits<A>::value_type const& const_reference;
+    typedef typename std::allocator_traits<A>::pointer pointer;
+    typedef typename std::allocator_traits<A>::const_pointer const_pointer;
+#endif
 
     typedef typename Storage::iterator iterator;
     typedef typename Storage::const_iterator const_iterator;


### PR DESCRIPTION
This PR fixes the compilation problem caused by the removal of some member typdef in std::allocator since C++20 standard.

```
In file included from ./boost/wave/wave_config.hpp:230,
                 from libs/wave/src/instantiate_cpp_exprgrammar.cpp:14:
./boost/wave/util/flex_string.hpp: In instantiation of ‘class boost::wave::util::CowString<boost::wave::util::AllocatorStringStorage<char> >’:
./boost/wave/util/flex_string.hpp:1417:7:   required from ‘class boost::wave::util::flex_string<char, std::char_traits<char>, std::allocator<char>, boost::wave::util::CowString<boost::wave::util::AllocatorStringStorage<char> > >’
./boost/wave/util/file_position.hpp:85:17:   required from ‘struct boost::wave::util::file_position<boost::wave::util::flex_string<char, std::char_traits<char>, std::allocator<char>, boost::wave::util::CowString<boost::wave::util::AllocatorStringStorage<char> > > >’
./boost/wave/util/file_position.hpp:161:16:   required from here
./boost/wave/util/flex_string.hpp:1205:41: error: no type named ‘reference’ in ‘class boost::wave::util::AllocatorStringStorage<char>’
 1205 |     typedef typename Storage::reference reference;
      |                                         ^~~~~~~~~
./boost/wave/util/flex_string.hpp: In instantiation of ‘class boost::wave::util::flex_string<char, std::char_traits<char>, std::allocator<char>, boost::wave::util::CowString<boost::wave::util::AllocatorStringStorage<char> > >’:
./boost/wave/util/file_position.hpp:85:17:   required from ‘struct boost::wave::util::file_position<boost::wave::util::flex_string<char, std::char_traits<char>, std::allocator<char>, boost::wave::util::CowString<boost::wave::util::AllocatorStringStorage<char> > > >’
./boost/wave/util/file_position.hpp:161:16:   required from here
./boost/wave/util/flex_string.hpp:1467:35: error: no type named ‘reference’ in ‘class std::allocator<char>’
 1467 |     typedef typename A::reference reference;
      |                                   ^~~~~~~~~
./boost/wave/util/flex_string.hpp:1468:41: error: no type named ‘const_reference’ in ‘class std::allocator<char>’
 1468 |     typedef typename A::const_reference const_reference;
      |                                         ^~~~~~~~~~~~~~~
./boost/wave/util/flex_string.hpp:1469:33: error: no type named ‘pointer’ in ‘class std::allocator<char>’
 1469 |     typedef typename A::pointer pointer;
      |                                 ^~~~~~~
./boost/wave/util/flex_string.hpp:1470:39: error: no type named ‘const_pointer’ in ‘class std::allocator<char>’
 1470 |     typedef typename A::const_pointer const_pointer;
      |                                       ^~~~~~~~~~~~~
```