### PR TITLE
Repair xlex and add to test suite

### DIFF
--- a/samples/token_statistics/collect_token_statistics.hpp
+++ b/samples/token_statistics/collect_token_statistics.hpp
@@ -38,7 +38,7 @@ public:
     {
         using boost::wave::token_id;
         
-        int id = token_id(token) - boost::wave::T_FIRST_TOKEN;
+        int id = ID_FROM_TOKEN(token) - boost::wave::T_FIRST_TOKEN;
         BOOST_ASSERT(id < count);
         ++token_count[id];
     }

--- a/samples/token_statistics/instantiate_xlex_lexer.cpp
+++ b/samples/token_statistics/instantiate_xlex_lexer.cpp
@@ -19,7 +19,6 @@
 #include <boost/wave/token_ids.hpp>
 
 #include <boost/wave/cpplexer/cpp_lex_token.hpp>
-#include "xlex_iterator.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
 //  The following file needs to be included only once throughout the whole

--- a/samples/token_statistics/xlex/xlex_lexer.hpp
+++ b/samples/token_statistics/xlex/xlex_lexer.hpp
@@ -124,7 +124,7 @@ private:
 #define TRI(c)              Q("?") Q("?") c
 
 // definition of some subtoken regexps to simplify the regex definitions
-#define BLANK               "[ \t]"
+#define BLANK               "[ \t\v\f]"
 #define CCOMMENT            Q("/") Q("*") ".*?" Q("*") Q("/")
         
 #define PPSPACE             "(" BLANK OR CCOMMENT ")*"
@@ -360,7 +360,6 @@ lexer<Iterator, Position>::init_data[] =
     TOKEN_DATA(T_IDENTIFIER, "([a-zA-Z_$]" OR UNIVERSALCHAR ")([a-zA-Z0-9_$]" OR UNIVERSALCHAR ")*"),
 #endif
     TOKEN_DATA(T_SPACE, BLANK "+"),
-    TOKEN_DATA(T_SPACE2, "[\v\f]+"),
     TOKEN_DATA(T_CONTLINE, Q("\\") "\n"), 
     TOKEN_DATA(T_NEWLINE, NEWLINEDEF),
     TOKEN_DATA(T_POUND_POUND, "##"),

--- a/samples/token_statistics/xlex/xlex_lexer.hpp
+++ b/samples/token_statistics/xlex/xlex_lexer.hpp
@@ -35,7 +35,7 @@
 #include <boost/wave/cpplexer/cpp_lex_interface.hpp>
 
 // reuse the default token type 
-#include "../xlex_iterator.hpp"
+#include "../xlex_interface.hpp"
 
 // include the xpressive headers
 #include "xpressive_lexer.hpp"

--- a/test/build/Jamfile.v2
+++ b/test/build/Jamfile.v2
@@ -166,6 +166,32 @@ test-suite wave
                 test_re2c_lexer
         ]
 
+        # test the xlex wave lexing component
+        [
+            run
+            # sources
+                ../testlexers/test_xlex_lexer.cpp
+                /boost/wave//boost_wave
+                /boost/program_options//boost_program_options
+                /boost/filesystem//boost_filesystem
+                /boost/thread//boost_thread
+                /boost/system//boost_system
+                /boost/date_time//boost_date_time
+            :
+            # arguments
+            :
+            # input files
+            :
+            # requirements
+                <threading>multi
+                <variant>debug
+                <toolset>msvc:<define>_SCL_SECURE_NO_DEPRECATE
+                <toolset>msvc:<define>_CRT_SECURE_NO_DEPRECATE
+            :
+            # name
+                test_xlex_lexer
+        ]
+
         [
             run
             # sources

--- a/test/testlexers/test_xlex_lexer.cpp
+++ b/test/testlexers/test_xlex_lexer.cpp
@@ -25,6 +25,7 @@
 //  include the Xpressive lexer related stuff
 #include <boost/wave/cpplexer/cpp_lex_token.hpp>                  // token type
 #include <libs/wave/samples/token_statistics/xlex/xlex_lexer.hpp> // lexer type
+#include <libs/wave/samples/token_statistics/xlex_iterator.hpp>   // iterator
 
 typedef boost::wave::cpplexer::lex_token<> token_type;
 typedef boost::wave::cpplexer::xlex::xlex_iterator<token_type> lexer_type;


### PR DESCRIPTION
Fix xlex and the token_statistics sample by:

- Changing space handling to match lexertl so lexer test passes
- Adding xlex to test Jamfile
- Adding remedial line/column tracking to xlex (positions were often reported as 0:-1)
- Fixing token_statistics id index for counting
