### PR TITLE
Remove linking to newly header-only date_time

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -36,7 +36,6 @@ lib boost_wave
     $(SOURCES)
     ../../filesystem/build//boost_filesystem
     ../../thread/build//boost_thread
-    ../../date_time/build//boost_date_time
     ;
 
 for local source in $(SOURCES)

--- a/samples/advanced_hooks/build/Jamfile.v2
+++ b/samples/advanced_hooks/build/Jamfile.v2
@@ -12,7 +12,6 @@ exe advanced_hooks
     :   ../advanced_hooks.cpp 
         /boost/wave//boost_wave
         /boost/thread//boost_thread
-        /boost/date_time//boost_date_time
         /boost/filesystem//boost_filesystem
     ;  
 

--- a/samples/cpp_tokens/build/Jamfile.v2
+++ b/samples/cpp_tokens/build/Jamfile.v2
@@ -25,7 +25,6 @@ exe cpp_tokens
         /boost/filesystem//boost_filesystem     
         /boost/system//boost_system     
         /boost/thread//boost_thread
-        /boost/date_time//boost_date_time
     ;
 
 for local source in $(SOURCES)

--- a/samples/custom_directives/build/Jamfile.v2
+++ b/samples/custom_directives/build/Jamfile.v2
@@ -12,7 +12,6 @@ exe custom_directives
     :   ../custom_directives.cpp 
         /boost/wave//boost_wave
         /boost/thread//boost_thread
-        /boost/date_time//boost_date_time
         /boost/filesystem//boost_filesystem
     ;  
 

--- a/samples/emit_custom_line_directives/build/Jamfile.v2
+++ b/samples/emit_custom_line_directives/build/Jamfile.v2
@@ -12,7 +12,6 @@ exe emit_custom_line_directives
     :   ../emit_custom_line_directives.cpp 
         /boost/wave//boost_wave
         /boost/thread//boost_thread
-        /boost/date_time//boost_date_time
         /boost/filesystem//boost_filesystem
     ;  
 

--- a/samples/hannibal/build/Jamfile.v2
+++ b/samples/hannibal/build/Jamfile.v2
@@ -15,6 +15,5 @@ exe hannibal
         /boost/program_options//boost_program_options
         /boost/system//boost_system
         /boost/thread//boost_thread
-        /boost/date_time//boost_date_time
     ;  
 

--- a/samples/lexed_tokens/build/Jamfile.v2
+++ b/samples/lexed_tokens/build/Jamfile.v2
@@ -14,6 +14,5 @@ exe lexed_tokens
         /boost/filesystem//boost_filesystem
         /boost/system//boost_system
         /boost/thread//boost_thread
-        /boost/date_time//boost_date_time
     ;  
 

--- a/samples/list_includes/build/Jamfile.v2
+++ b/samples/list_includes/build/Jamfile.v2
@@ -25,7 +25,6 @@ exe list_includes
         /boost/filesystem//boost_filesystem     
         /boost/system//boost_system     
         /boost/thread//boost_thread
-        /boost/date_time//boost_date_time
     ;
 
 for local source in $(SOURCES)

--- a/samples/preprocess_pragma_output/build/Jamfile.v2
+++ b/samples/preprocess_pragma_output/build/Jamfile.v2
@@ -12,7 +12,6 @@ exe preprocess_pragma_output
     :   ../preprocess_pragma_output.cpp 
         /boost/wave//boost_wave
         /boost/thread//boost_thread
-        /boost/date_time//boost_date_time
         /boost/filesystem//boost_filesystem
         /boost/system//boost_system
     :

--- a/samples/quick_start/build/Jamfile.v2
+++ b/samples/quick_start/build/Jamfile.v2
@@ -13,7 +13,6 @@ exe quick_start
         /boost/wave//boost_wave
         /boost/system//boost_system
         /boost/thread//boost_thread
-        /boost/date_time//boost_date_time
         /boost/filesystem//boost_filesystem
     ;  
 

--- a/samples/real_positions/build/Jamfile.v2
+++ b/samples/real_positions/build/Jamfile.v2
@@ -20,6 +20,5 @@ exe real_positions
         /boost/filesystem//boost_filesystem
         /boost/system//boost_system
         /boost/thread//boost_thread
-        /boost/date_time//boost_date_time
     ;  
 

--- a/samples/token_statistics/build/Jamfile.v2
+++ b/samples/token_statistics/build/Jamfile.v2
@@ -23,7 +23,6 @@ exe token_statistics
         /boost/filesystem//boost_filesystem     
         /boost/system//boost_system     
         /boost/thread//boost_thread
-        /boost/date_time//boost_date_time
     ;
 
 for local source in $(SOURCES)

--- a/samples/waveidl/build/Jamfile.v2
+++ b/samples/waveidl/build/Jamfile.v2
@@ -25,7 +25,6 @@ exe waveidl
         /boost/program_options//boost_program_options/<link>static
         /boost/system//boost_system
         /boost/thread//boost_thread
-        /boost/date_time//boost_date_time
         /boost/filesystem//boost_filesystem
     ;
 

--- a/test/build/Jamfile.v2
+++ b/test/build/Jamfile.v2
@@ -65,7 +65,6 @@ test-suite wave
                 /boost/filesystem//boost_filesystem    
                 /boost/system//boost_system    
                 /boost/thread//boost_thread
-                /boost/date_time//boost_date_time
             :
             # arguments
                 $(TESTWAVE_ARGUMENTS) 
@@ -95,7 +94,6 @@ test-suite wave
                 /boost/filesystem//boost_filesystem/<link>static
                 /boost/system//boost_system/<link>static
                 /boost/thread//boost_thread/<link>static
-                /boost/date_time//boost_date_time/<link>static
             :
             # arguments
                 $(TESTWAVE_ARGUMENTS) 
@@ -125,7 +123,6 @@ test-suite wave
                 /boost/filesystem//boost_filesystem
                 /boost/thread//boost_thread
                 /boost/system//boost_system
-                /boost/date_time//boost_date_time
             :
             # arguments
             :
@@ -150,7 +147,6 @@ test-suite wave
                 /boost/filesystem//boost_filesystem
                 /boost/thread//boost_thread
                 /boost/system//boost_system
-                /boost/date_time//boost_date_time
             :
             # arguments
             :
@@ -176,7 +172,6 @@ test-suite wave
                 /boost/filesystem//boost_filesystem
                 /boost/thread//boost_thread
                 /boost/system//boost_system
-                /boost/date_time//boost_date_time
             :
             # arguments
             :
@@ -206,7 +201,6 @@ test-suite wave
                 /boost/filesystem//boost_filesystem
                 /boost/thread//boost_thread
                 /boost/system//boost_system
-                /boost/date_time//boost_date_time
             :
             # arguments
             :

--- a/tool/build/Jamfile.v2
+++ b/tool/build/Jamfile.v2
@@ -40,7 +40,6 @@ exe wave
     /boost//serialization
     /boost//system
     /boost//thread
-    /boost//date_time
     /boost/timer//boost_timer/<link>static
     :
     <threading>multi


### PR DESCRIPTION
Boost develop branch has an updated date_time that is header-only so
Wave's builds will now fail unless this dependency is removed.