### PR TITLE
Remove use of deprecated header boost/detail/iterator.hpp

### DIFF
--- a/samples/token_statistics/xlex/xpressive_lexer.hpp
+++ b/samples/token_statistics/xlex/xpressive_lexer.hpp
@@ -16,9 +16,9 @@
 #include <string>
 #include <vector>
 #include <utility>
+#include <iterator>
 #include <algorithm>
 
-#include <boost/detail/iterator.hpp>
 #include <boost/xpressive/xpressive.hpp>
 
 namespace boost {
@@ -36,7 +36,7 @@ template <
 class xpressive_lexer
 {
 private:
-    typedef typename boost::iterators::iterator_value<Iterator>::type
+    typedef typename std::iterator_traits<Iterator>::value_type
         char_type;
     typedef std::basic_string<char_type> string_type;
     


### PR DESCRIPTION
The header is deprecated in favor of `<iterator>`. It generates compiler warnings and will be removed in a future release.

Also, added a missing include for `iterator_value` trait.
