### PR TITLE
Remove unused headers

### DIFF
--- a/include/boost/wave/cpplexer/re2clex/cpp_re.hpp
+++ b/include/boost/wave/cpplexer/re2clex/cpp_re.hpp
@@ -43,7 +43,7 @@
     }                                                                         \
     /**/
 
-#include <iostream>
+#include <iosfwd>
 
 ///////////////////////////////////////////////////////////////////////////////
 #define BOOST_WAVE_UPDATE_CURSOR()                                            \

--- a/samples/cpp_tokens/cpp_tokens.cpp
+++ b/samples/cpp_tokens/cpp_tokens.cpp
@@ -30,6 +30,8 @@
 #include "slex/cpp_slex_lexer.hpp"
 #endif // !defined(BOOST_WAVE_SEPARATE_LEXER_INSTANTIATION)
 
+#include <iostream>
+
 ///////////////////////////////////////////////////////////////////////////////
 //  import required names
 using namespace boost::spirit::classic;

--- a/samples/cpp_tokens/cpp_tokens.hpp
+++ b/samples/cpp_tokens/cpp_tokens.hpp
@@ -18,7 +18,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 //  include often used files from the stdlib
-#include <iostream>
+#include <iosfwd>
 #include <fstream>
 #include <string>
 

--- a/samples/cpp_tokens/slex/lexer.hpp
+++ b/samples/cpp_tokens/slex/lexer.hpp
@@ -54,7 +54,9 @@
 #include <vector>
 #include <stack>
 #include <utility> // for pair
+#if defined(BOOST_SPIRIT_DEBUG)
 #include <iostream>
+#endif
 #include <fstream>
 #include <boost/assert.hpp>
 #include <boost/limits.hpp>

--- a/samples/cpp_tokens/slex_iterator.hpp
+++ b/samples/cpp_tokens/slex_iterator.hpp
@@ -14,7 +14,7 @@
 #define SLEX_ITERATOR_HPP_AF0C37E3_CBD8_4F33_A225_51CF576FA61F_INCLUDED
 
 #include <string>
-#include <iostream>
+#include <iosfwd>
 
 #include <boost/assert.hpp>
 #include <boost/shared_ptr.hpp>

--- a/samples/hannibal/translation_unit_parser.h
+++ b/samples/hannibal/translation_unit_parser.h
@@ -13,6 +13,9 @@
 #define HANNIBAL_TRANSLATION_UNIT_GRAMMAR_H_INCLUDED
 
 #include <map>
+#if defined(HANNIBAL_TRACE_DECLARATIONS)
+#include <iostream>
+#endif
 
 #include <boost/assert.hpp>
 #include <boost/spirit/include/classic_core.hpp>

--- a/samples/lexed_tokens/lexed_tokens.cpp
+++ b/samples/lexed_tokens/lexed_tokens.cpp
@@ -12,7 +12,6 @@
 #include <iomanip>
 #include <fstream>
 #include <string>
-#include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
 //  Include Wave itself

--- a/samples/list_includes/list_includes.cpp
+++ b/samples/list_includes/list_includes.cpp
@@ -36,6 +36,8 @@
 // Include the default context trace policies
 #include <boost/wave/preprocessing_hooks.hpp>
 
+#include <iostream>
+
 ///////////////////////////////////////////////////////////////////////////////
 //  include lexer specifics, import lexer names
 #if BOOST_WAVE_SEPARATE_LEXER_INSTANTIATION == 0

--- a/samples/list_includes/list_includes.hpp
+++ b/samples/list_includes/list_includes.hpp
@@ -16,7 +16,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 //  include often used files from the stdlib
-#include <iostream>
+#include <iosfwd>
 #include <fstream>
 #include <string>
 #include <vector>

--- a/samples/token_statistics/collect_token_statistics.hpp
+++ b/samples/token_statistics/collect_token_statistics.hpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <map>
+#include <iostream>
 
 #include <boost/assert.hpp>
 #include <boost/wave/token_ids.hpp>

--- a/samples/token_statistics/token_statistics.cpp
+++ b/samples/token_statistics/token_statistics.cpp
@@ -26,6 +26,8 @@
 
 #include "collect_token_statistics.hpp"
 
+#include <iostream>
+
 ///////////////////////////////////////////////////////////////////////////////
 //  import required names
 using namespace boost::spirit::classic;

--- a/samples/token_statistics/token_statistics.hpp
+++ b/samples/token_statistics/token_statistics.hpp
@@ -15,7 +15,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 //  include often used files from the stdlib
-#include <iostream>
+#include <iosfwd>
 #include <fstream>
 #include <string>
 #include <vector>

--- a/samples/token_statistics/xlex_iterator.hpp
+++ b/samples/token_statistics/xlex_iterator.hpp
@@ -14,7 +14,7 @@
 #define XLEX_ITERATOR_HPP
 
 #include <string>
-#include <iostream>
+#include <iosfwd>
 
 #include <boost/assert.hpp>
 #include <boost/shared_ptr.hpp>

--- a/samples/waveidl/idl.cpp
+++ b/samples/waveidl/idl.cpp
@@ -32,6 +32,8 @@
 #include "idllexer/idl_re2c_lexer.hpp"
 #endif 
 
+#include <iostream>
+
 ///////////////////////////////////////////////////////////////////////////////
 //  include the grammar definitions, if these shouldn't be compiled separately
 //  (ATTENTION: _very_ large compilation times!)

--- a/samples/waveidl/idl.hpp
+++ b/samples/waveidl/idl.hpp
@@ -18,7 +18,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 //  include often used files from the stdlib
-#include <iostream>
+#include <iosfwd>
 #include <fstream>
 #include <string>
 #include <vector>

--- a/samples/waveidl/idllexer/idl_lex_iterator.hpp
+++ b/samples/waveidl/idllexer/idl_lex_iterator.hpp
@@ -15,7 +15,7 @@
 #define IDL_LEX_ITERATOR_HPP_7926F865_E02F_4950_9EB5_5F453C9FF953_INCLUDED
 
 #include <string>
-#include <iostream>
+#include <iosfwd>
 
 #include <boost/assert.hpp>
 #include <boost/shared_ptr.hpp>

--- a/samples/waveidl/idllexer/idl_re.cpp
+++ b/samples/waveidl/idllexer/idl_re.cpp
@@ -10,14 +10,6 @@
     LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
 
-#include <ctime>
-#include <cstdlib>
-#include <cstdio>
-#include <cstring>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-
 #include <boost/config.hpp>
 
 #if defined(BOOST_HAS_UNISTD_H)

--- a/samples/waveidl/idllexer/idl_re.hpp
+++ b/samples/waveidl/idllexer/idl_re.hpp
@@ -13,16 +13,9 @@
 #if !defined(IDL_RE_HPP_BD62775D_1659_4684_872C_03C02543C9A5_INCLUDED)
 #define IDL_RE_HPP_BD62775D_1659_4684_872C_03C02543C9A5_INCLUDED
 
-#include <ctime>
-#include <cstdlib>
 #include <cstdio>
-#include <cstring>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
 
 #include <string>
-
 #include <boost/config.hpp>
 
 #if defined(BOOST_HAS_UNISTD_H)

--- a/src/cpplexer/re2clex/cpp_re.cpp
+++ b/src/cpplexer/re2clex/cpp_re.cpp
@@ -17,13 +17,7 @@
 // disable stupid compiler warnings
 #include <boost/config/warning_disable.hpp>
 
-#include <ctime>
-#include <cstdlib>
-#include <cstdio>
-#include <cstring>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <cstddef>
 
 #include <boost/wave/wave_config.hpp>          // configuration data
 
@@ -36,7 +30,6 @@
 #include <boost/detail/workaround.hpp>
 
 #include <boost/wave/token_ids.hpp>
-#include <boost/wave/cpplexer/re2clex/aq.hpp>
 #include <boost/wave/cpplexer/re2clex/scanner.hpp>
 #include <boost/wave/cpplexer/re2clex/cpp_re.hpp>
 

--- a/src/wave_config_constant.cpp
+++ b/src/wave_config_constant.cpp
@@ -14,7 +14,6 @@
 // disable stupid compiler warnings
 #include <boost/config/warning_disable.hpp>
 
-#include <cstring>
 #include <boost/preprocessor/stringize.hpp>
 
 #include <boost/wave/wave_config.hpp>

--- a/test/testlexers/test_lexertl_lexer.cpp
+++ b/test/testlexers/test_lexertl_lexer.cpp
@@ -9,8 +9,10 @@
 
 //  system headers
 #include <string>
-#include <iostream>
 #include <limits>
+#if defined(TESTLEXERS_TIMING)
+#include <iostream>
+#endif
 
 #include <boost/wave/wave_config.hpp>
 #undef BOOST_WAVE_SEPARATE_LEXER_INSTANTIATION

--- a/test/testlexers/test_re2c_lexer.cpp
+++ b/test/testlexers/test_re2c_lexer.cpp
@@ -11,8 +11,10 @@
 #include <boost/config/warning_disable.hpp>
 
 //  system headers
-#include <string>
+#if defined(TESTLEXERS_TIMING)
 #include <iostream>
+#endif
+
 #include <limits>
 
 #include <boost/wave/wave_config.hpp>

--- a/test/testlexers/test_slex_lexer.cpp
+++ b/test/testlexers/test_slex_lexer.cpp
@@ -12,7 +12,9 @@
 
 //  system headers
 #include <string>
+#if defined(TESTLEXERS_TIMING)
 #include <iostream>
+#endif
 #include <limits>
 
 #include <boost/wave/wave_config.hpp>

--- a/test/testlexers/test_xlex_lexer.cpp
+++ b/test/testlexers/test_xlex_lexer.cpp
@@ -12,7 +12,9 @@
 
 //  system headers
 #include <string>
+#if defined(TESTLEXERS_TIMING)
 #include <iostream>
+#endif
 #include <limits>
 
 #include <boost/wave/wave_config.hpp>

--- a/test/testwave/testwave_app.cpp
+++ b/test/testwave/testwave_app.cpp
@@ -12,7 +12,7 @@
 
 // system headers
 #include <string>
-#include <iostream>
+#include <iosfwd>
 #include <vector>
 #include <ctime>
 

--- a/tool/cpp.cpp
+++ b/tool/cpp.cpp
@@ -36,6 +36,8 @@
 #include <boost/wave/cpplexer/cpp_lex_token.hpp>      // token type
 #include <boost/wave/cpplexer/cpp_lex_iterator.hpp>   // lexer type
 
+#include <iostream>
+
 ///////////////////////////////////////////////////////////////////////////////
 //  Include serialization support, if requested
 #if BOOST_WAVE_SERIALIZATION != 0

--- a/tool/cpp.hpp
+++ b/tool/cpp.hpp
@@ -16,7 +16,7 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 //  include often used files from the stdlib
-#include <iostream>
+#include <iosfwd>
 #include <string>
 #include <vector>
 #include <algorithm>


### PR DESCRIPTION
Reduce build time by:
- using iosfwd instead of iostream, where possible
- where iostream is necessary but only used for debugging,
  making its inclusion conditional
- removing old C-style headers

I used IWYU to guide this work