### PR TITLE
Deprecate C++03 and re-deprecate the old preprocessor hooks

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -24,6 +24,7 @@ Boost V1.74:
   - Repaired two samples and added a new one for macro naming enforcement
   - Implemented C++20 changes for variadic macros, including __VA_OPT__()
   - Added C++17 feature __has_include()
+  - Deprecate C++98 and C++03. Support will end with 1.77.
 
 Boost V1.73:
   - Fixed TRAC #7822: waveidl sample does not use the IDL lexer

--- a/doc/class_ref_ctxpolicy_depr.html
+++ b/doc/class_ref_ctxpolicy_depr.html
@@ -32,7 +32,7 @@
 </blockquote>
 <h2><b><a name="introduction"></a>Introduction</b></h2>
 <p>Please note that the following description relates to a depreciated interface as it was used by default up to Boost V1.34.x. For the new interface please refer to <a href="class_reference_ctxpolicy.html">The Context Policy</a>. You can still force to use this older interface by defining the <tt>BOOST_WAVE_USE_DEPRECIATED_PREPROCESSING_HOOKS</tt> preprocessing constant as outlined in the <a href="compiletime_config.html">Compile 
-Time Configuration</a> section. By default the new interface is used starting Boost V1.35.0, while the older one is used by default otherwise. </p>
+Time Configuration</a> section. By default the new interface is used starting Boost V1.35.0, while the older one is used by default otherwise. The old interface will be removed entirely with Boost 1.76.</p>
 <p>The context policy is used to provide callback hooks, which are called from inside the library into the user code, whenever</p>
 <ul>
   <li>a preprocessor directive has been recognized, </li>

--- a/doc/compiletime_config.html
+++ b/doc/compiletime_config.html
@@ -244,6 +244,8 @@ even if these do not have the <span class="literal">'ll'</span> suffix.</p>
   where the <span class="string">'...somthing'</span> is a hint, which grammars 
   are explicitly instantiated inside. By using the separation model the compilation
   times required to build the <tt>Wave</tt> example are dropped by up to 90%.</p>
+<P dir="ltr"><b><a name="compiler_requirements"></a>Compiler Requirements</b></P>
+<p>Beginning with version 1.77, Wave will require building with C++11 features, and will no longer support the use of older compilers. However, Wave will continue to <em>emulate</em> the features of older preprocessors indefinitely.<p>
 <table border="0">
   <tr> 
     <td width="10"></td>

--- a/include/boost/wave/wave_config.hpp
+++ b/include/boost/wave/wave_config.hpp
@@ -14,6 +14,7 @@
 #define BOOST_WAVE_CONFIG_HPP_F143F90A_A63F_4B27_AC41_9CA4F14F538D_INCLUDED
 
 #include <boost/config.hpp>
+#include <boost/config/pragma_message.hpp>
 #include <boost/detail/workaround.hpp>
 #include <boost/version.hpp>
 #include <boost/spirit/include/classic_version.hpp>
@@ -516,6 +517,16 @@ namespace boost { namespace wave
 #endif  // BOOST_VERSION
 
 ///////////////////////////////////////////////////////////////////////////////
+//  Deprecate C++03
+///////////////////////////////////////////////////////////////////////////////
+
+#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) || defined(BOOST_NO_CXX11_RVALUE_REFERENCES) || defined(BOOST_NO_CXX11_HDR_MEMORY)
+
+BOOST_PRAGMA_MESSAGE("C++03 support is deprecated in Boost.Wave 1.74 and will be removed in Boost.Wave 1.77.")
+
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
 //  Compatibility macros
 //  (ensure interface compatibility to older Wave versions)
 ///////////////////////////////////////////////////////////////////////////////
@@ -535,6 +546,8 @@ namespace boost { namespace wave
 #else
 #define BOOST_WAVE_USE_DEPRECIATED_PREPROCESSING_HOOKS 0
 #endif
+#elif BOOST_WAVE_USE_DEPRECIATED_PREPROCESSING_HOOKS != 0
+BOOST_PRAGMA_MESSAGE("The old preprocessing hooks were deprecated in Boost 1.35 and will be removed in 1.76. See https://www.boost.org/doc/libs/1_74_0/libs/wave/doc/class_ref_ctxpolicy_depr.html for details")
 #endif
 
 #endif // !defined(BOOST_WAVE_CONFIG_HPP_F143F90A_A63F_4B27_AC41_9CA4F14F538D_INCLUDED)

--- a/include/boost/wave/wave_config.hpp
+++ b/include/boost/wave/wave_config.hpp
@@ -520,7 +520,9 @@ namespace boost { namespace wave
 //  Deprecate C++03
 ///////////////////////////////////////////////////////////////////////////////
 
-#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) || defined(BOOST_NO_CXX11_RVALUE_REFERENCES) || defined(BOOST_NO_CXX11_HDR_MEMORY)
+#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) || defined(BOOST_NO_CXX11_RVALUE_REFERENCES) \
+    || defined(BOOST_NO_CXX11_HDR_MEMORY) || defined(BOOST_NO_CXX11_HDR_THREAD) \
+    || defined(BOOST_NO_CXX11_HDR_MUTEX) || defined(BOOST_NO_CXX11_HDR_REGEX)
 
 BOOST_PRAGMA_MESSAGE("C++03 support is deprecated in Boost.Wave 1.74 and will be removed in Boost.Wave 1.77.")
 


### PR DESCRIPTION
Targeting a one year transition period for C++03 -> C++11, and one release less to finally get off the old hooks - assuming there are even any users of them.