### PR TITLE
Track the location tokens were expanded from, for __LINE__ and __FILE__

### DIFF
--- a/include/boost/wave/cpplexer/cpp_lex_token.hpp
+++ b/include/boost/wave/cpplexer/cpp_lex_token.hpp
@@ -24,6 +24,7 @@
 #include <boost/throw_exception.hpp>
 #include <boost/pool/singleton_pool.hpp>
 #include <boost/detail/atomic_count.hpp>
+#include <boost/optional.hpp>
 
 // this must occur after all of the includes and before any code appears
 #ifdef BOOST_HAS_ABI_HEADERS
@@ -54,12 +55,14 @@ public:
     :   id(T_UNKNOWN), refcnt(1)
     {}
 
-    token_data(token_id id_, string_type const &value_, position_type const &pos_)
-    :   id(id_), value(value_), pos(pos_), refcnt(1)
+    token_data(token_id id_, string_type const &value_,
+               position_type const &pos_,
+               optional<position_type> const & expand_pos_ = boost::none)
+    :   id(id_), value(value_), pos(pos_), expand_pos(expand_pos_), refcnt(1)
     {}
 
     token_data(token_data const& rhs)
-    :   id(rhs.id), value(rhs.value), pos(rhs.pos), refcnt(1)
+    :   id(rhs.id), value(rhs.value), pos(rhs.pos), expand_pos(rhs.expand_pos), refcnt(1)
     {}
 
     ~token_data()
@@ -73,10 +76,18 @@ public:
     operator token_id() const { return id; }
     string_type const &get_value() const { return value; }
     position_type const &get_position() const { return pos; }
+    position_type const &get_expand_position() const
+    {
+        if (expand_pos)
+            return *expand_pos;
+        else
+            return pos;
+    }
 
     void set_token_id (token_id id_) { id = id_; }
     void set_value (string_type const &value_) { value = value_; }
     void set_position (position_type const &pos_) { pos = pos_; }
+    void set_expand_position (position_type const & pos_) { expand_pos = pos_; }
 
     friend bool operator== (token_data const& lhs, token_data const& rhs)
     {
@@ -138,6 +149,7 @@ private:
     token_id id;                // the token id
     string_type value;          // the text, which was parsed into this token
     position_type pos;          // the original file position
+    boost::optional<position_type> expand_pos;    // where this token was expanded
     boost::detail::atomic_count refcnt;
 };
 
@@ -241,12 +253,14 @@ public:
     operator token_id() const { return 0 != data ? token_id(*data) : T_EOI; }
     string_type const &get_value() const { return data->get_value(); }
     position_type const &get_position() const { return data->get_position(); }
+    position_type const &get_expand_position() const { return data->get_expand_position(); }
     bool is_eoi() const { return 0 == data || token_id(*data) == T_EOI; }
     bool is_valid() const { return 0 != data && token_id(*data) != T_UNKNOWN; }
 
     void set_token_id (token_id id_) { make_unique(); data->set_token_id(id_); }
     void set_value (string_type const &value_) { make_unique(); data->set_value(value_); }
     void set_position (position_type const &pos_) { make_unique(); data->set_position(pos_); }
+    void set_expand_position (position_type const &pos_) { make_unique(); data->set_expand_position(pos_); }
 
     friend bool operator== (lex_token const& lhs, lex_token const& rhs)
     {

--- a/samples/cpp_tokens/slex_token.hpp
+++ b/samples/cpp_tokens/slex_token.hpp
@@ -20,6 +20,7 @@
 #include <boost/wave/token_ids.hpp>  
 #include <boost/wave/language_support.hpp>
 #include <boost/wave/util/file_position.hpp>
+#include <boost/optional.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace boost {
@@ -61,12 +62,19 @@ public:
     operator token_id() const { return id; }
     string_type const &get_value() const { return value; }
     position_type const &get_position() const { return pos; }
+    position_type const &get_expand_position() const {
+        if (expand_pos)
+            return *expand_pos;
+        else
+            return pos;
+    }
     bool is_eoi() const { return id == T_EOI; }
     bool is_valid() const { return id != T_UNKNOWN; }
 
     void set_token_id (token_id id_) { id = id_; }
     void set_value (string_type const &newval) { value = newval; }
     void set_position (position_type const &pos_) { pos = pos_; }
+    void set_expand_position (position_type const &pos_) { expand_pos = pos_; }
 
     friend bool operator== (slex_token const& lhs, slex_token const& rhs)
     {
@@ -115,6 +123,7 @@ private:
     boost::wave::token_id id;   // the token id
     string_type value;             // the text, which was parsed into this token
     PositionT pos;              // the original file position
+    boost::optional<PositionT> expand_pos;
 };
 
 template <typename PositionT>

--- a/samples/real_positions/real_position_token.hpp
+++ b/samples/real_positions/real_position_token.hpp
@@ -18,6 +18,7 @@
 #include <boost/wave/token_ids.hpp>  
 #include <boost/wave/language_support.hpp>
 #include <boost/detail/atomic_count.hpp>
+#include <boost/optional.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace impl {
@@ -61,6 +62,13 @@ public:
     position_type const &get_position() const { return pos; }
     position_type const &get_corrected_position() const 
         { return corrected_pos; }
+    position_type const &get_expand_position() const
+    {
+        if (expand_pos)
+            return *expand_pos;
+        else
+            return pos;
+    }
     bool is_eoi() const
     {
         return id == boost::wave::T_EOI;
@@ -71,6 +79,8 @@ public:
     void set_position (position_type const &pos_) { pos = pos_; }
     void set_corrected_position (position_type const &pos_) 
         { corrected_pos = pos_; }
+    void set_expand_position (position_type const & pos_)
+        { expand_pos = pos_; }
 
     friend bool operator== (token_data const& lhs, token_data const& rhs)
     {
@@ -84,6 +94,7 @@ private:
     string_type value;            // the text, which was parsed into this token
     position_type pos;            // the original file position
     position_type corrected_pos;  // the original file position
+    boost::optional<position_type> expand_pos;  // where this token was expanded
     boost::detail::atomic_count refcnt;
 };
 
@@ -157,6 +168,8 @@ public:
         { return data->get_position(); }
     position_type const &get_corrected_position() const 
         { return data->get_corrected_position(); }
+    position_type const &get_expand_position() const
+        { return data->get_expand_position(); }
     bool is_valid() const
     {
         using namespace boost::wave;
@@ -171,6 +184,8 @@ public:
         { make_unique(); data->set_position(pos_); }
     void set_corrected_position (position_type const &pos_) 
         { make_unique(); data->set_corrected_position(pos_); }
+    void set_expand_position (position_type const &pos_)
+        { make_unique(); data->set_expand_position(pos_); }
 
     friend bool operator== (lex_token const& lhs, lex_token const& rhs)
     {

--- a/test/testwave/testfiles/t_5_036.cpp
+++ b/test/testwave/testfiles/t_5_036.cpp
@@ -1,0 +1,28 @@
+/*=============================================================================
+    Boost.Wave: A Standard compliant C++ preprocessor library
+    http://www.boost.org/
+
+    Copyright (c) 2020 Jeff Trull. Distributed under the Boost
+    Software License, Version 1.0. (See accompanying file
+    LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+    Part of the test included in this file was taken from a tweet by
+    Eric Niebler: https://twitter.com/ericniebler/status/1252660334545866752
+=============================================================================*/
+
+// Test __LINE__ and __FILE__ in a context where the invocation of the macro
+// that uses them is split across two lines
+
+// __LINE__ should reflect the position where the macros are expanded
+#define FOO(X) __LINE__ __FILE__ BAR
+#define BAR(X) __LINE__ __FILE__
+FOO(X)
+  (Y)
+//R #line 19 "t_5_036.cpp"
+//R 19 "$F" 19 "$F"
+
+// now use those same macros in a different file -
+// __FILE__ should report that.
+#include "t_5_036.hpp"
+//R #line 11 "t_5_036.hpp"
+//R 11 "$P(t_5_036.hpp)" 11 "$P(t_5_036.hpp)"

--- a/test/testwave/testfiles/t_5_036.hpp
+++ b/test/testwave/testfiles/t_5_036.hpp
@@ -1,0 +1,12 @@
+/*=============================================================================
+    Boost.Wave: A Standard compliant C++ preprocessor library
+    http://www.boost.org/
+
+    Copyright (c) 2020 Jeff Trull. Distributed under the Boost
+    Software License, Version 1.0. (See accompanying file
+    LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+
+// use macro defined in the parent file
+FOO(X)
+  (Y)

--- a/test/testwave/testfiles/t_5_037.cpp
+++ b/test/testwave/testfiles/t_5_037.cpp
@@ -1,0 +1,79 @@
+/*=============================================================================
+    Boost.Wave: A Standard compliant C++ preprocessor library
+    http://www.boost.org/
+
+    Copyright (c) 2020 Jeff Trull. Distributed under the Boost
+    Software License, Version 1.0. (See accompanying file
+    LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+    The body of this test is taken directly from a standard proposal:
+    http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1911.htm
+=============================================================================*/
+
+
+#line 500
+  #define MAC(a,b) a,b,__LINE__
+
+  #line 1000
+int j[] = {__LINE__, __\
+LINE\
+__,
+
+#line 2000
+#line __\
+LINE\
+__
+    __LINE__,
+
+#line 3000
+#line                                                                          \
+                                                                               \
+                                                                               \
+    __LINE__
+
+
+    /**/
+    __LINE__,
+
+    MAC(__LINE__, __LINE__),
+
+    MAC(__LINE__, __LINE__), __LINE__,
+
+    M\
+A\
+C
+
+    (
+
+        __\
+LINE\
+__,
+        __LINE__
+
+        ),
+    __LINE__,
+
+    M\
+A\
+C(__\
+LINE\
+__,
+        __LINE__),
+    __LINE__, 999};
+
+//R #line 1000 "t_5_037.cpp"
+//R int j[] = {1000, 1000,
+//R #line 2000 "t_5_037.cpp"
+//R 2000,
+//R #line 3006 "t_5_037.cpp"
+//R 3006,
+//R 
+//R 3008, 3008,3008,
+//R 
+//R 3010, 3010,3010, 3010,
+//R 
+//R 3018, 3021 ,3012,
+//R 3024,
+//R #line 3026 "t_5_037.cpp"
+//R 3028, 3031,3026,
+//R 3032, 999};

--- a/test/testwave/testfiles/test.cfg
+++ b/test/testwave/testfiles/test.cfg
@@ -141,6 +141,8 @@ t_5_032.cpp
 t_5_033.cpp
 t_5_034.cpp
 t_5_035.cpp
+t_5_036.cpp
+t_5_037.cpp
 
 #
 # unit tests from the mcpp preprocessor validation suite


### PR DESCRIPTION
An (optional) extra position field is added to token_data and set for
any identifier token created from a macro expansion. This information
is used to correctly calculate the filename and line number.

If merged, this will resolve #94.

NOT intended for Boost 1.74.