### PR TITLE
Remove use of non-existent Boost.Config macro BOOST_NO_CXX11_HDR_MEMORY

### DIFF
--- a/include/boost/wave/wave_config.hpp
+++ b/include/boost/wave/wave_config.hpp
@@ -521,7 +521,7 @@ namespace boost { namespace wave
 ///////////////////////////////////////////////////////////////////////////////
 
 #if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) || defined(BOOST_NO_CXX11_RVALUE_REFERENCES) \
-    || defined(BOOST_NO_CXX11_HDR_MEMORY) || defined(BOOST_NO_CXX11_HDR_THREAD) \
+    || defined(BOOST_NO_CXX11_HDR_THREAD) \
     || defined(BOOST_NO_CXX11_HDR_MUTEX) || defined(BOOST_NO_CXX11_HDR_REGEX)
 
 BOOST_PRAGMA_MESSAGE("C++03 support is deprecated in Boost.Wave 1.74 and will be removed in Boost.Wave 1.77.")


### PR DESCRIPTION
Thanks to Jeff Trull for the catch.