### PR TITLE
Clarify loop logic to satisfy a Clang warning

### DIFF
--- a/samples/preprocess_pragma_output/preprocess_pragma_output.hpp
+++ b/samples/preprocess_pragma_output/preprocess_pragma_output.hpp
@@ -115,7 +115,6 @@ public:
         typename Context::token_type const& option, 
         Container const& values, typename Context::token_type const& act_token)
     {
-        typedef typename Context::token_type token_type;
         typedef typename Context::iterator_type iterator_type;
 
         if (option.get_value() == "pp")  {
@@ -140,10 +139,10 @@ public:
                 Container pragma;
                 iterator_type end = ctx.end();
                 for (iterator_type it = ctx.begin(s.begin(), s.end()); 
-                     it != end && token_id(*it) != T_EOF; ++it) 
+                     it != end && token_id(*it) != T_EOF;
+                     std::advance(it, 2))  // skip over whitespace
                 {
                     pragma.push_back(*it);
-                    it++;
                 }
 
             // prepend the newly generated token sequence to the 'pending' 


### PR DESCRIPTION
Clang warns that a for loop in a sample increments an iterator in both
the header and the body. This seems to be done on purpose to skip
whitespace. I used std::advance in the header instead, for clarity.

Also cleaned up an unused type in the same file while I was there.

If merged, this will resolve #90