### PR TITLE
Feature/appveyor msvc improvements

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,9 @@ environment:
       TOOLSET: msvc-14.1
       CXXSTD: 14,17
       ADDRMD: 32,64
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      TOOLSET: msvc-14.2
+      CXXSTD: 14,17
 ##
 ## cygwin and mingw disabled for now, failing to build
 ## for reasons unrelated to wave

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       TOOLSET: msvc-9.0,msvc-10.0,msvc-11.0,msvc-12.0
+      ADDRMD: 32
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       TOOLSET: msvc-14.0
       ADDRMD: 32,64

--- a/include/boost/wave/grammars/cpp_intlit_grammar.hpp
+++ b/include/boost/wave/grammars/cpp_intlit_grammar.hpp
@@ -158,13 +158,12 @@ uint_literal_type
 intlit_grammar_gen<TokenT>::evaluate(TokenT const &token,
     bool &is_unsigned)
 {
-    using namespace boost::spirit::classic;
-
-intlit_grammar g(is_unsigned);
-uint_literal_type result = 0;
-typename TokenT::string_type const &token_val = token.get_value();
-parse_info<typename TokenT::string_type::const_iterator> hit =
-    parse(token_val.begin(), token_val.end(), g[spirit_assign_actor(result)]);
+    intlit_grammar g(is_unsigned);
+    uint_literal_type result = 0;
+    typename TokenT::string_type const &token_val = token.get_value();
+    using boost::spirit::classic::parse_info;
+    parse_info<typename TokenT::string_type::const_iterator> hit =
+        parse(token_val.begin(), token_val.end(), g[spirit_assign_actor(result)]);
 
     if (!hit.hit) {
         BOOST_WAVE_THROW(preprocess_exception, ill_formed_integer_literal,


### PR DESCRIPTION
Two changes:

1) work around an issue with 32b builds on MSVC
2) add VC++ 2019 to matrix

both using code from @pdimov . Test in progress on appveyor; I'll try to get this in for 1.75 if it passes.