### PR TITLE
Update GitHub Actions CI file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,8 @@ jobs:
             buildtype: "boost"
             packages: ""
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
+            container: "ubuntu:16.04"
             cxx: "g++"
             sources: ""
             llvm_os: ""
@@ -32,7 +33,8 @@ jobs:
             buildtype: "boost"
             packages: "g++-5"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
+            container: "ubuntu:16.04"
             cxx: "g++-5"
             sources: ""
             llvm_os: ""
@@ -43,7 +45,8 @@ jobs:
             buildtype: "boost"
             packages: "g++-6"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
+            container: "ubuntu:16.04"
             cxx: "g++-6"
             sources: ""
             llvm_os: ""
@@ -54,7 +57,8 @@ jobs:
             buildtype: "boost"
             packages: "g++-7"
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-20.04"
+            container: "ubuntu:16.04"
             cxx: "g++-7"
             sources: ""
             llvm_os: ""
@@ -65,7 +69,7 @@ jobs:
             buildtype: "boost"
             packages: ""
             packages_to_remove: ""
-            os: "ubuntu-16.04"
+            os: "ubuntu-18.04"
             cxx: "clang++"
             sources: ""
             llvm_os: ""
@@ -80,6 +84,16 @@ jobs:
       - name: Check if running in container
         if: matrix.container != ''
         run: echo "GHA_CONTAINER=${{ matrix.container }}" >> $GITHUB_ENV
+      - name: If running in container, upgrade packages
+        if: matrix.container != ''
+        run: |
+            apt-get -o Acquire::Retries=3 update && DEBIAN_FRONTEND=noninteractive apt-get -y install tzdata && apt-get -o Acquire::Retries=3 install -y sudo software-properties-common wget curl apt-transport-https make apt-file sudo unzip libssl-dev build-essential autotools-dev autoconf automake g++ libc++-helpers python ruby cpio gcc-multilib g++-multilib pkgconf python3 ccache libpython-dev
+            sudo apt-add-repository ppa:git-core/ppa
+            sudo apt-get -o Acquire::Retries=3 update && apt-get -o Acquire::Retries=3 -y install git
+            python_version=$(python3 -c 'import sys; print("{0.major}.{0.minor}".format(sys.version_info))')
+            sudo wget https://bootstrap.pypa.io/pip/$python_version/get-pip.py
+            sudo python3 get-pip.py
+            sudo /usr/local/bin/pip install cmake
 
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
The Ubuntu 16.04 environment is scheduled to be removed from GitHub Actions in September 2021. Migrate those jobs to Docker containers or Ubuntu 18.04. Also, fix a problem with pip package installation on older platforms.