### PR TITLE
Remove support for C++03 and prior compilers

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -14,12 +14,12 @@ windowsglobalimage="cppalliance/dronevs2019"
 
 def main(ctx):
   return [
-  linux_cxx("TOOLSET=gcc CXXSTD=03,11 Job 0", "g++", packages="", buildtype="boost", buildscript="drone", image=linuxglobalimage, environment={'TOOLSET': 'gcc', 'CXXSTD': '03,11', 'DRONE_JOB_UUID': 'b6589fc6ab'}, globalenv=globalenv),
-  linux_cxx("TOOLSET=gcc-5 CXXSTD=03,11,14,1z Job 1", "g++-5", packages="g++-5", buildtype="boost", buildscript="drone", image=linuxglobalimage, environment={'TOOLSET': 'gcc-5', 'CXXSTD': '03,11,14,1z', 'DRONE_JOB_UUID': '356a192b79'}, globalenv=globalenv),
-  linux_cxx("TOOLSET=gcc-6 CXXSTD=03,11,14,1z Job 2", "g++-6", packages="g++-6", buildtype="boost", buildscript="drone", image=linuxglobalimage, environment={'TOOLSET': 'gcc-6', 'CXXSTD': '03,11,14,1z', 'DRONE_JOB_UUID': 'da4b9237ba'}, globalenv=globalenv),
-  linux_cxx("TOOLSET=gcc-7 CXXSTD=03,11,14,17 Job 3", "g++-7", packages="g++-7", buildtype="boost", buildscript="drone", image=linuxglobalimage, environment={'TOOLSET': 'gcc-7', 'CXXSTD': '03,11,14,17', 'DRONE_JOB_UUID': '77de68daec'}, globalenv=globalenv),
-  linux_cxx("TOOLSET=clang CXXSTD=03,11,14,1z Job 4", "clang++", packages="", buildtype="boost", buildscript="drone", image=linuxglobalimage, environment={'TOOLSET': 'clang', 'CXXSTD': '03,11,14,1z', 'DRONE_JOB_UUID': '1b64538924'}, globalenv=globalenv),
-  osx_cxx("TOOLSET=clang CXXSTD=03,11,14,1z Job 5", "clang++", packages="", buildtype="boost", buildscript="drone", environment={'TOOLSET': 'clang', 'CXXSTD': '03,11,14,1z', 'DRONE_JOB_UUID': 'ac3478d69a'}, globalenv=globalenv),
+  linux_cxx("TOOLSET=gcc CXXSTD=11 Job 0", "g++", packages="", buildtype="boost", buildscript="drone", image=linuxglobalimage, environment={'TOOLSET': 'gcc', 'CXXSTD': '11', 'DRONE_JOB_UUID': 'b6589fc6ab'}, globalenv=globalenv),
+  linux_cxx("TOOLSET=gcc-5 CXXSTD=11,14,1z Job 1", "g++-5", packages="g++-5", buildtype="boost", buildscript="drone", image=linuxglobalimage, environment={'TOOLSET': 'gcc-5', 'CXXSTD': '11,14,1z', 'DRONE_JOB_UUID': '356a192b79'}, globalenv=globalenv),
+  linux_cxx("TOOLSET=gcc-6 CXXSTD=11,14,1z Job 2", "g++-6", packages="g++-6", buildtype="boost", buildscript="drone", image=linuxglobalimage, environment={'TOOLSET': 'gcc-6', 'CXXSTD': '11,14,1z', 'DRONE_JOB_UUID': 'da4b9237ba'}, globalenv=globalenv),
+  linux_cxx("TOOLSET=gcc-7 CXXSTD=11,14,17 Job 3", "g++-7", packages="g++-7", buildtype="boost", buildscript="drone", image=linuxglobalimage, environment={'TOOLSET': 'gcc-7', 'CXXSTD': '11,14,17', 'DRONE_JOB_UUID': '77de68daec'}, globalenv=globalenv),
+  linux_cxx("TOOLSET=clang CXXSTD=11,14,1z Job 4", "clang++", packages="", buildtype="boost", buildscript="drone", image=linuxglobalimage, environment={'TOOLSET': 'clang', 'CXXSTD': '11,14,1z', 'DRONE_JOB_UUID': '1b64538924'}, globalenv=globalenv),
+  osx_cxx("TOOLSET=clang CXXSTD=11,14,1z Job 5", "clang++", packages="", buildtype="boost", buildscript="drone", environment={'TOOLSET': 'clang', 'CXXSTD': '11,14,1z', 'DRONE_JOB_UUID': 'ac3478d69a'}, globalenv=globalenv),
     ]
 
 # from https://github.com/boostorg/boost-ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "TOOLSET=gcc CXXSTD=03,11 Job 0"
+          - name: "TOOLSET=gcc CXXSTD=11 Job 0"
             buildtype: "boost"
             packages: ""
             packages_to_remove: ""
@@ -28,8 +28,8 @@ jobs:
             llvm_os: ""
             llvm_ver: ""
             toolset: "gcc"
-            cxxstd: "03,11"
-          - name: "TOOLSET=gcc-5 CXXSTD=03,11,14,1z Job 1"
+            cxxstd: "11"
+          - name: "TOOLSET=gcc-5 CXXSTD=11,14,1z Job 1"
             buildtype: "boost"
             packages: "g++-5"
             packages_to_remove: ""
@@ -40,8 +40,8 @@ jobs:
             llvm_os: ""
             llvm_ver: ""
             toolset: "gcc-5"
-            cxxstd: "03,11,14,1z"
-          - name: "TOOLSET=gcc-6 CXXSTD=03,11,14,1z Job 2"
+            cxxstd: "11,14,1z"
+          - name: "TOOLSET=gcc-6 CXXSTD=11,14,1z Job 2"
             buildtype: "boost"
             packages: "g++-6"
             packages_to_remove: ""
@@ -52,8 +52,8 @@ jobs:
             llvm_os: ""
             llvm_ver: ""
             toolset: "gcc-6"
-            cxxstd: "03,11,14,1z"
-          - name: "TOOLSET=gcc-7 CXXSTD=03,11,14,17 Job 3"
+            cxxstd: "11,14,1z"
+          - name: "TOOLSET=gcc-7 CXXSTD=11,14,17 Job 3"
             buildtype: "boost"
             packages: "g++-7"
             packages_to_remove: ""
@@ -64,8 +64,8 @@ jobs:
             llvm_os: ""
             llvm_ver: ""
             toolset: "gcc-7"
-            cxxstd: "03,11,14,17"
-          - name: "TOOLSET=clang CXXSTD=03,11,14,1z Job 4"
+            cxxstd: "11,14,17"
+          - name: "TOOLSET=clang CXXSTD=11,14,1z Job 4"
             buildtype: "boost"
             packages: ""
             packages_to_remove: ""
@@ -75,7 +75,7 @@ jobs:
             llvm_os: ""
             llvm_ver: ""
             toolset: "clang"
-            cxxstd: "03,11,14,1z"
+            cxxstd: "11,14,1z"
 
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
@@ -178,7 +178,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "TOOLSET=clang CXXSTD=03,11,14,1z Job 5"
+          - name: "TOOLSET=clang CXXSTD=11,14,1z Job 5"
             buildtype: "boost"
             packages: ""
             os: "macos-10.15"
@@ -188,7 +188,7 @@ jobs:
             llvm_ver: ""
             xcode_version: 11.7
             toolset: "clang"
-            cxxstd: "03,11,14,1z"
+            cxxstd: "11,14,1z"
 
     runs-on: ${{ matrix.os }}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,11 @@ matrix:
   include:
     - os: linux
       compiler: g++
-      env: TOOLSET=gcc CXXSTD=03,11
+      env: TOOLSET=gcc CXXSTD=11
 
     - os: linux
       compiler: g++-5
-      env: TOOLSET=gcc-5 CXXSTD=03,11,14,1z
+      env: TOOLSET=gcc-5 CXXSTD=11,14,1z
       addons:
         apt:
           packages:
@@ -40,7 +40,7 @@ matrix:
 
     - os: linux
       compiler: g++-6
-      env: TOOLSET=gcc-6 CXXSTD=03,11,14,1z
+      env: TOOLSET=gcc-6 CXXSTD=11,14,1z
       addons:
         apt:
           packages:
@@ -50,7 +50,7 @@ matrix:
 
     - os: linux
       compiler: g++-7
-      env: TOOLSET=gcc-7 CXXSTD=03,11,14,17
+      env: TOOLSET=gcc-7 CXXSTD=11,14,17
       addons:
         apt:
           packages:
@@ -60,11 +60,11 @@ matrix:
 
     - os: linux
       compiler: clang++
-      env: TOOLSET=clang CXXSTD=03,11,14,1z
+      env: TOOLSET=clang CXXSTD=11,14,1z
 
     - os: osx
       compiler: clang++
-      env: TOOLSET=clang CXXSTD=03,11,14,1z
+      env: TOOLSET=clang CXXSTD=11,14,1z
 
 install:
   - BOOST_BRANCH=develop && [ "$TRAVIS_BRANCH" == "master" ] && BOOST_BRANCH=master || true

--- a/ChangeLog
+++ b/ChangeLog
@@ -18,8 +18,8 @@ TODO (known issues):
 
 CHANGELOG
 
-Boost V1.78:
-  - Removed support for C++03 (as a compiler), previously deprecated in 1.74
+Boost V1.79:
+  - Removed support for C++03 (as a compiler) - previously deprecated in 1.74
 	
 Boost V1.75:
   - Introduced C++20 tokens, including the spaceship operator

--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,9 @@ TODO (known issues):
 
 CHANGELOG
 
+Boost V1.78:
+  - Removed support for C++03 (as a compiler), previously deprecated in 1.74
+	
 Boost V1.75:
   - Introduced C++20 tokens, including the spaceship operator
   - Fixed #94: Tricky line number tracking logic for __LINE__ and __FILE__

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,19 +34,19 @@ environment:
 #    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
 #      ADDPATH: C:\cygwin\bin;
 #      TOOLSET: gcc
-#      CXXSTD: 03,11,14,1z
+#      CXXSTD: 11,14,1z
 #    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
 #      ADDPATH: C:\cygwin64\bin;
 #      TOOLSET: gcc
-#      CXXSTD: 03,11,14,1z
+#      CXXSTD: 11,14,1z
 #    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
 #      ADDPATH: C:\mingw\bin;
 #      TOOLSET: gcc
-#      CXXSTD: 03,11,14,1z
+#      CXXSTD: 11,14,1z
 #    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
 #      ADDPATH: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin;
 #      TOOLSET: gcc
-#      CXXSTD: 03,11,14,1z
+#      CXXSTD: 11,14,1z
 
 install:
   - set BOOST_BRANCH=develop

--- a/include/boost/wave/wave_config.hpp
+++ b/include/boost/wave/wave_config.hpp
@@ -524,7 +524,7 @@ namespace boost { namespace wave
     || defined(BOOST_NO_CXX11_HDR_THREAD) \
     || defined(BOOST_NO_CXX11_HDR_MUTEX) || defined(BOOST_NO_CXX11_HDR_REGEX)
 
-#error "C++03 support is deprecated in Boost.Wave 1.74 and was removed in Boost.Wave 1.78."
+#error "C++03 support is deprecated in Boost.Wave 1.74 and was removed in Boost.Wave 1.79."
 
 #endif
 

--- a/include/boost/wave/wave_config.hpp
+++ b/include/boost/wave/wave_config.hpp
@@ -524,7 +524,7 @@ namespace boost { namespace wave
     || defined(BOOST_NO_CXX11_HDR_THREAD) \
     || defined(BOOST_NO_CXX11_HDR_MUTEX) || defined(BOOST_NO_CXX11_HDR_REGEX)
 
-BOOST_PRAGMA_MESSAGE("C++03 support is deprecated in Boost.Wave 1.74 and will be removed in Boost.Wave 1.77.")
+#error "C++03 support is deprecated in Boost.Wave 1.74 and was removed in Boost.Wave 1.78."
 
 #endif
 


### PR DESCRIPTION
This removes only support for C++98/03 as a compiler for this library - Wave continues to support C++98 and C++03 constructs as a preprocessor.

Support for C++98 and C++03 compilers was deprecated in 1.74, with a warning message.

Doing this enables the use of C++11 constructs in the code, which should help maintainability.