### PR TITLE
Specify C++11 requirement in top-level Jamfile

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,7 +20,7 @@ CHANGELOG
 
 Boost V1.79:
   - Removed support for C++03 (as a compiler) - previously deprecated in 1.74
-	
+
 Boost V1.75:
   - Introduced C++20 tokens, including the spaceship operator
   - Fixed #94: Tricky line number tracking logic for __LINE__ and __FILE__

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -8,8 +8,17 @@
 # Software License, Version 1.0. (See accompanying file 
 # LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+import ../../config/checks/config : requires ;
+
 project boost/wave
     : requirements
+      [ requires
+        cxx11_variadic_templates
+        cxx11_rvalue_references
+        cxx11_hdr_thread
+        cxx11_hdr_mutex
+        cxx11_hdr_regex
+      ]
       <link>shared:<define>BOOST_ALL_DYN_LINK=1
       <link>static:<define>BOOST_THREAD_USE_LIB=1
       <toolset>msvc:<define>_SCL_SECURE_NO_DEPRECATE


### PR DESCRIPTION
Removing C++03 from Wave's CI config isn't enough - the top-level Boost
build will try to build Wave under unsupported standards/compiler versions
without an explicit requirement in the Jamfile.