### PR TITLE
Qualify "newline at EOF not required" with actually being there

### DIFF
--- a/include/boost/wave/util/cpp_iterator.hpp
+++ b/include/boost/wave/util/cpp_iterator.hpp
@@ -966,7 +966,8 @@ namespace impl {
             if (call_hook)
                 util::impl::call_skipped_token_hook(ctx, *it);
         }
-        return need_no_newline_at_end_of_file(ctx.get_language());
+        return need_no_newline_at_end_of_file(ctx.get_language()) &&
+            ((it == end) || (T_EOF == token_id(*it)));
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/test/testwave/testfiles/t_2_031.cpp
+++ b/test/testwave/testfiles/t_2_031.cpp
@@ -1,0 +1,20 @@
+/*=============================================================================
+    Boost.Wave: A Standard compliant C++ preprocessor library
+    http://www.boost.org/
+
+    Copyright (c) 2001-2012 Hartmut Kaiser. Distributed under the Boost
+    Software License, Version 1.0. (See accompanying file
+    LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+
+//O --c++11
+
+// test the error reporting for unknown directives in C++11 mode
+// (newline at EOF not required)
+
+//R
+//E t_2_031.cpp(17): error: ill formed preprocessor directive: #this_is_a_unknown_pp_directive with some parameter
+#this_is_a_unknown_pp_directive with some parameter
+
+//H 21: t_2_031.cpp(17): #this_is_a_unknown_pp_directive with some parameter
+//H 18: boost::wave::preprocess_exception

--- a/test/testwave/testfiles/t_2_031.cpp
+++ b/test/testwave/testfiles/t_2_031.cpp
@@ -2,7 +2,8 @@
     Boost.Wave: A Standard compliant C++ preprocessor library
     http://www.boost.org/
 
-    Copyright (c) 2001-2012 Hartmut Kaiser. Distributed under the Boost
+    Copyright (c) 2001-2012 Hartmut Kaiser.
+    Copyright (c) 2022 Jeff Trull. Distributed under the Boost
     Software License, Version 1.0. (See accompanying file
     LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 =============================================================================*/
@@ -13,8 +14,8 @@
 // (newline at EOF not required)
 
 //R
-//E t_2_031.cpp(17): error: ill formed preprocessor directive: #this_is_a_unknown_pp_directive with some parameter
+//E t_2_031.cpp(18): error: ill formed preprocessor directive: #this_is_a_unknown_pp_directive with some parameter
 #this_is_a_unknown_pp_directive with some parameter
 
-//H 21: t_2_031.cpp(17): #this_is_a_unknown_pp_directive with some parameter
+//H 21: t_2_031.cpp(18): #this_is_a_unknown_pp_directive with some parameter
 //H 18: boost::wave::preprocess_exception

--- a/test/testwave/testfiles/test.cfg
+++ b/test/testwave/testfiles/test.cfg
@@ -83,6 +83,7 @@ t_2_027.cpp
 t_2_028.cpp
 t_2_029.cpp
 t_2_030.cpp
+t_2_031.cpp
 
 #
 # t_3: Predefined macros


### PR DESCRIPTION
In C++11 and later modes Wave by default does not require newline prior to EOF. This works fine but
there is one place where the test for this feature was used where Wave is not necessarily looking at the end of the file: `pp_is_last_on_line`. One observable (and surprising) result is that unknown
directives are not getting flagged - but there may be others. The unit tests did not discover this
problem because they generally do not set c++11 mode.

This PR adds the necessary qualifiers and adds a unit test (the same as an existing one but with
C++11 enabled).

If merged this will resolve #137 