### PR TITLE
Clarify the purpose of the single_line language option

### DIFF
--- a/doc/class_reference_context.html
+++ b/doc/class_reference_context.html
@@ -406,10 +406,10 @@
     <li>If the <tt>support_option_convert_trigraphs</tt> flag is set, the <tt>Wave</tt> library replaces all
       occurrences of trigraph characters with their non-trigraph character
       sequence (i.e. <tt>'??='</tt> is replaced by <tt>'#'</tt> etc.) . By default no replacement is performed. </li>
-    <li>If the <tt>support_option_single_line</tt> flag is set, the <tt>Wave</tt> library will now report an
+    <li>If the <tt>support_option_single_line</tt> flag is set, the <tt>Wave</tt> library runs in <em>single line</em> mode and, among other things, will not report an
       error if the last line of the processed input is not terminated by a
-      new line. This flag is merely used for internal purposes by the testing
-      framework and will be rarely used by a user of the library.</li>
+      new line. This flag is mainly used for internal purposes by the testing
+      framework and will be rarely used by a user of the library. To disable newline at end of file checking, use <tt>support_option_no_newline_at_end_of_file</tt> (the default for C++11 and later).</li>
     <li>If the <tt>support_option_prefer_pp_numbers</tt> flag is set, the <tt>Wave</tt> library is instructed to
       correctly identify pp-number's in the input stream. These get
       recognized into 'normal' number tokens before they get returned to the


### PR DESCRIPTION
It currently says Wave "will now" report an error for input which is not terminated by a newline. In fact it "will not" do that.

I also made some descriptive edits that made sense to me personally.