### PR TITLE
Clean up sprintf usage

### DIFF
--- a/include/boost/wave/util/cpp_macromap_predef.hpp
+++ b/include/boost/wave/util/cpp_macromap_predef.hpp
@@ -47,14 +47,14 @@ namespace util {
         typedef BOOST_WAVE_STRINGTYPE string_type;
 
     public:
-    // list of static predefined macros
+        // list of static predefined macros
         struct static_macros {
             char const *name;
             boost::wave::token_id token_id;
             char const *value;
         };
 
-    // list of dynamic predefined macros
+        // list of dynamic predefined macros
         struct dynamic_macros {
             char const *name;
             boost::wave::token_id token_id;
@@ -71,23 +71,23 @@ namespace util {
     protected:
         void reset_datestr()
         {
-        static const char *const monthnames[] = {
+            static const char *const monthnames[] = {
                 "Jan", "Feb", "Mar", "Apr", "May", "Jun",
                 "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
             };
 
-        // for some systems sprintf, time_t etc. is in namespace std
+            // for some systems sprintf, time_t etc. is in namespace std
             using namespace std;
 
-        time_t tt = time(0);
-        struct tm *tb = 0;
+            time_t tt = time(0);
+            struct tm *tb = 0;
 
             if (tt != (time_t)-1) {
-            char buffer[sizeof("\"Oct 11 1347\"")+1];
+                char buffer[sizeof("\"Oct 11 1347\"")+1];
 
                 tb = localtime (&tt);
                 sprintf (buffer, "\"%s %2d %4d\"",
-                    monthnames[tb->tm_mon], tb->tm_mday, tb->tm_year + 1900);
+                         monthnames[tb->tm_mon], tb->tm_mday, tb->tm_year + 1900);
                 datestr_ = buffer;
             }
             else {
@@ -97,18 +97,18 @@ namespace util {
 
         void reset_timestr()
         {
-        // for some systems sprintf, time_t etc. is in namespace std
+            // for some systems sprintf, time_t etc. is in namespace std
             using namespace std;
 
-        time_t tt = time(0);
-        struct tm *tb = 0;
+            time_t tt = time(0);
+            struct tm *tb = 0;
 
             if (tt != (time_t)-1) {
-            char buffer[sizeof("\"12:34:56\"")+1];
+                char buffer[sizeof("\"12:34:56\"")+1];
 
                 tb = localtime (&tt);
                 sprintf (buffer, "\"%02d:%02d:%02d\"", tb->tm_hour,
-                    tb->tm_min, tb->tm_sec);
+                         tb->tm_min, tb->tm_sec);
                 timestr_ = buffer;
             }
             else {
@@ -120,12 +120,12 @@ namespace util {
         {
         char buffer[sizeof("0x00000000")+1];
 
-        // for some systems sprintf, time_t etc. is in namespace std
+            // for some systems sprintf, time_t etc. is in namespace std
             using namespace std;
 
-        // calculate the number of days since Dec 13 2001
-        // (the day the Wave project was started)
-        tm first_day;
+            // calculate the number of days since Dec 13 2001
+            // (the day the Wave project was started)
+            tm first_day;
 
             using namespace std;    // for some systems memset is in namespace std
             memset (&first_day, 0, sizeof(tm));
@@ -133,7 +133,7 @@ namespace util {
             first_day.tm_mday = 13;          // 13
             first_day.tm_year = 101;         // 2001
 
-        long seconds = long(difftime(compilation_time_.get_time(), mktime(&first_day)));
+            long seconds = long(difftime(compilation_time_.get_time(), mktime(&first_day)));
 
             sprintf(buffer, "0x%02d%1d%1d%04ld", BOOST_WAVE_VERSION_MAJOR,
                  BOOST_WAVE_VERSION_MINOR, BOOST_WAVE_VERSION_SUBMINOR,
@@ -143,44 +143,44 @@ namespace util {
 
         void reset_versionstr()
         {
-        char buffer[sizeof("\"00.00.00.0000 \"")+sizeof(BOOST_PLATFORM)+sizeof(BOOST_COMPILER)+4];
+            char buffer[sizeof("\"00.00.00.0000 \"")+sizeof(BOOST_PLATFORM)+sizeof(BOOST_COMPILER)+4];
 
-        // for some systems sprintf, time_t etc. is in namespace std
+            // for some systems sprintf, time_t etc. is in namespace std
             using namespace std;
 
-        // calculate the number of days since Dec 13 2001
-        // (the day the Wave project was started)
-        tm first_day;
+            // calculate the number of days since Dec 13 2001
+            // (the day the Wave project was started)
+            tm first_day;
 
             memset (&first_day, 0, sizeof(tm));
             first_day.tm_mon = 11;           // Dec
             first_day.tm_mday = 13;          // 13
             first_day.tm_year = 101;         // 2001
 
-        long seconds = long(difftime(compilation_time_.get_time(), mktime(&first_day)));
+            long seconds = long(difftime(compilation_time_.get_time(), mktime(&first_day)));
 
             sprintf(buffer, "\"%d.%d.%d.%ld [%s/%s]\"", BOOST_WAVE_VERSION_MAJOR,
-                 BOOST_WAVE_VERSION_MINOR, BOOST_WAVE_VERSION_SUBMINOR,
-                 seconds/(3600*24), BOOST_PLATFORM, BOOST_COMPILER);
+                    BOOST_WAVE_VERSION_MINOR, BOOST_WAVE_VERSION_SUBMINOR,
+                    seconds/(3600*24), BOOST_PLATFORM, BOOST_COMPILER);
             versionstr_ = buffer;
         }
 
-    // dynamic predefined macros
+        // dynamic predefined macros
         string_type get_date() const { return datestr_; }     // __DATE__
         string_type get_time() const { return timestr_; }     // __TIME__
 
-    // __SPIRIT_PP__/__WAVE__
+        // __SPIRIT_PP__/__WAVE__
         string_type get_version() const
         {
             char buffer[sizeof("0x0000")+1];
 
             using namespace std;    // for some systems sprintf is in namespace std
             sprintf(buffer, "0x%02d%1d%1d", BOOST_WAVE_VERSION_MAJOR,
-                BOOST_WAVE_VERSION_MINOR, BOOST_WAVE_VERSION_SUBMINOR);
+                    BOOST_WAVE_VERSION_MINOR, BOOST_WAVE_VERSION_SUBMINOR);
             return buffer;
         }
 
-    // __WAVE_CONFIG__
+        // __WAVE_CONFIG__
         string_type get_config() const
         {
             char buffer[sizeof("0x00000000")+1];
@@ -205,13 +205,13 @@ namespace util {
             reset_timestr();
         }
 
-    // __SPIRIT_PP_VERSION__/__WAVE_VERSION__
+        // __SPIRIT_PP_VERSION__/__WAVE_VERSION__
         string_type get_fullversion() const { return version_; }
 
-    // __SPIRIT_PP_VERSION_STR__/__WAVE_VERSION_STR__
+        // __SPIRIT_PP_VERSION_STR__/__WAVE_VERSION_STR__
         string_type get_versionstr() const { return versionstr_; }
 
-    // C++ mode
+        // C++ mode
         static_macros const& static_data_cpp(std::size_t i) const
         {
         static static_macros data[] = {
@@ -224,7 +224,7 @@ namespace util {
         }
 
 #if BOOST_WAVE_SUPPORT_CPP0X != 0
-    // C++11 mode
+        // C++11 mode
         static_macros const& static_data_cpp0x(std::size_t i) const
         {
         static static_macros data[] = {
@@ -241,7 +241,7 @@ namespace util {
 #endif
 
 #if BOOST_WAVE_SUPPORT_CPP2A != 0
-    // C++20 mode
+        // C++20 mode
         static_macros const& static_data_cpp2a(std::size_t i) const
         {
         static static_macros data[] = {
@@ -258,7 +258,7 @@ namespace util {
 #endif
 
 #if BOOST_WAVE_SUPPORT_VARIADICS_PLACEMARKERS != 0
-    // C99 mode
+        // C99 mode
         static_macros const& static_data_c99(std::size_t i) const
         {
         static static_macros data[] = {

--- a/include/boost/wave/util/cpp_macromap_predef.hpp
+++ b/include/boost/wave/util/cpp_macromap_predef.hpp
@@ -15,6 +15,7 @@
 
 #include <cstdio>
 #include <boost/assert.hpp>
+#include <boost/format.hpp>
 
 #include <boost/wave/wave_config.hpp>
 #include <boost/wave/wave_config_constant.hpp>
@@ -68,6 +69,11 @@ namespace util {
         string_type version_;     // __SPIRIT_PP_VERSION__/__WAVE_VERSION__
         string_type versionstr_;  // __SPIRIT_PP_VERSION_STR__/__WAVE_VERSION_STR__
 
+        static string_type strconv(std::string const & ss)
+        {
+            return string_type(ss.c_str());
+        }
+
     protected:
         void reset_datestr()
         {
@@ -83,12 +89,11 @@ namespace util {
             struct tm *tb = 0;
 
             if (tt != (time_t)-1) {
-                char buffer[sizeof("\"Oct 11 1347\"")+1];
-
                 tb = localtime (&tt);
-                sprintf (buffer, "\"%s %2d %4d\"",
-                         monthnames[tb->tm_mon], tb->tm_mday, tb->tm_year + 1900);
-                datestr_ = buffer;
+                datestr_ = strconv((boost::format("\"%s %2d %4d\"")
+                                    % monthnames[tb->tm_mon]
+                                    % tb->tm_mday
+                                    % (tb->tm_year + 1900)).str());
             }
             else {
                 datestr_ = "\"??? ?? ????\"";
@@ -104,12 +109,11 @@ namespace util {
             struct tm *tb = 0;
 
             if (tt != (time_t)-1) {
-                char buffer[sizeof("\"12:34:56\"")+1];
-
                 tb = localtime (&tt);
-                sprintf (buffer, "\"%02d:%02d:%02d\"", tb->tm_hour,
-                         tb->tm_min, tb->tm_sec);
-                timestr_ = buffer;
+                timestr_ = strconv((boost::format("\"%02d:%02d:%02d\"")
+                                    % tb->tm_hour
+                                    % tb->tm_min
+                                    % tb->tm_sec).str());
             }
             else {
                 timestr_ = "\"??:??:??\"";
@@ -118,8 +122,6 @@ namespace util {
 
         void reset_version()
         {
-        char buffer[sizeof("0x00000000")+1];
-
             // for some systems sprintf, time_t etc. is in namespace std
             using namespace std;
 
@@ -135,16 +137,15 @@ namespace util {
 
             long seconds = long(difftime(compilation_time_.get_time(), mktime(&first_day)));
 
-            sprintf(buffer, "0x%02d%1d%1d%04ld", BOOST_WAVE_VERSION_MAJOR,
-                 BOOST_WAVE_VERSION_MINOR, BOOST_WAVE_VERSION_SUBMINOR,
-                 seconds/(3600*24));
-            version_ = buffer;
+            version_ = strconv((boost::format("0x%02d%1d%1d%04ld")
+                                % BOOST_WAVE_VERSION_MAJOR
+                                % BOOST_WAVE_VERSION_MINOR
+                                % BOOST_WAVE_VERSION_SUBMINOR
+                                % (seconds/(3600*24))).str());
         }
 
         void reset_versionstr()
         {
-            char buffer[sizeof("\"00.00.00.0000 \"")+sizeof(BOOST_PLATFORM)+sizeof(BOOST_COMPILER)+4];
-
             // for some systems sprintf, time_t etc. is in namespace std
             using namespace std;
 
@@ -159,10 +160,13 @@ namespace util {
 
             long seconds = long(difftime(compilation_time_.get_time(), mktime(&first_day)));
 
-            sprintf(buffer, "\"%d.%d.%d.%ld [%s/%s]\"", BOOST_WAVE_VERSION_MAJOR,
-                    BOOST_WAVE_VERSION_MINOR, BOOST_WAVE_VERSION_SUBMINOR,
-                    seconds/(3600*24), BOOST_PLATFORM, BOOST_COMPILER);
-            versionstr_ = buffer;
+            versionstr_ = strconv((boost::format("\"%d.%d.%d.%ld [%s/%s]\"")
+                                   % BOOST_WAVE_VERSION_MAJOR
+                                   % BOOST_WAVE_VERSION_MINOR
+                                   % BOOST_WAVE_VERSION_SUBMINOR
+                                   % (seconds/(3600*24))
+                                   % BOOST_PLATFORM
+                                   % BOOST_COMPILER).str());
         }
 
         // dynamic predefined macros
@@ -172,22 +176,16 @@ namespace util {
         // __SPIRIT_PP__/__WAVE__
         string_type get_version() const
         {
-            char buffer[sizeof("0x0000")+1];
-
-            using namespace std;    // for some systems sprintf is in namespace std
-            sprintf(buffer, "0x%02d%1d%1d", BOOST_WAVE_VERSION_MAJOR,
-                    BOOST_WAVE_VERSION_MINOR, BOOST_WAVE_VERSION_SUBMINOR);
-            return buffer;
+            return strconv((boost::format("0x%02d%1d%1d")
+                            % BOOST_WAVE_VERSION_MAJOR
+                            % BOOST_WAVE_VERSION_MINOR
+                            % BOOST_WAVE_VERSION_SUBMINOR).str());
         }
 
         // __WAVE_CONFIG__
         string_type get_config() const
         {
-            char buffer[sizeof("0x00000000")+1];
-
-            using namespace std;     // for some systems sprintf is in namespace std
-            sprintf(buffer, "0x%08x", BOOST_WAVE_CONFIG);
-            return buffer;
+            return strconv((boost::format("0x%08x") % BOOST_WAVE_CONFIG).str());
         }
 
     public:

--- a/include/boost/wave/util/flex_string.hpp
+++ b/include/boost/wave/util/flex_string.hpp
@@ -101,7 +101,6 @@ class StoragePolicy
 
 #include <memory>
 #include <new>
-#include <string>
 #include <vector>
 #include <algorithm>
 #include <functional>

--- a/samples/emit_custom_line_directives/emit_custom_line_directives.hpp
+++ b/samples/emit_custom_line_directives/emit_custom_line_directives.hpp
@@ -63,9 +63,9 @@ public:
     emit_line_directive(ContextT const& ctx, ContainerT &pending, 
         typename ContextT::token_type const& act_token)
     {
-    // emit a #line directive showing the relative filename instead
-    typename ContextT::position_type pos = act_token.get_position();
-    unsigned int column = 1;
+        // emit a #line directive showing the relative filename instead
+        typename ContextT::position_type pos = act_token.get_position();
+        unsigned int column = 1;
 
         typedef typename ContextT::token_type result_type;
         using namespace boost::wave;
@@ -76,21 +76,16 @@ public:
         pos.set_column(++column);      // account for '#'
         pending.push_back(result_type(T_SPACE, " ", pos));
 
-    // 21 is the max required size for a 64 bit integer represented as a 
-    // string
-    char buffer[22];
-
-        using namespace std;    // for some systems sprintf is in namespace std
-        sprintf (buffer, "%d", pos.get_line());
+        std::string buffer = std::to_string(pos.get_line());
 
         pos.set_column(++column);                 // account for ' '
-        pending.push_back(result_type(T_INTLIT, buffer, pos));
-        pos.set_column(column += (unsigned int)strlen(buffer)); // account for <number>
+        pending.push_back(result_type(T_INTLIT, buffer.c_str(), pos));
+        pos.set_column(column += buffer.size()); // account for <number>
         pending.push_back(result_type(T_SPACE, " ", pos));
         pos.set_column(++column);                 // account for ' '
 
-    std::string file("\"");
-    boost::filesystem::path filename(
+        std::string file("\"");
+        boost::filesystem::path filename(
         boost::wave::util::create_path(ctx.get_current_relative_filename().c_str()));
 
         using boost::wave::util::impl::escape_lit;

--- a/tool/stop_watch.hpp
+++ b/tool/stop_watch.hpp
@@ -12,6 +12,7 @@
 
 #include <boost/config.hpp>
 #include <boost/timer/timer.hpp>
+#include <boost/format.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 //  
@@ -24,28 +25,27 @@ public:
         boost::timer::cpu_times times = elapsed();
         double current = static_cast<double>(times.user + times.system) / 1.e9;
 
-        char time_buffer[sizeof("1234:56:78.90 abcd.") + 1];
-
-        using namespace std;
         if (current >= 3600) {
             // show hours
-            sprintf (time_buffer, "%d:%02d:%02d.%03d hrs.",
-                (int)(current) / 3600, ((int)(current) % 3600) / 60,
-                ((int)(current) % 3600) % 60, 
-                (int)(current * 1000) % 1000);
+            return (boost::format("%d:%02d:%02d.%03d hrs.")
+                    % ((int)(current) / 3600)
+                    % (((int)(current) % 3600) / 60)
+                    % (((int)(current) % 3600) % 60)
+                    % ((int)(current * 1000) % 1000)).str();
         }
         else if (current >= 60) {
             // show minutes
-            sprintf (time_buffer, "%d:%02d.%03d min.", 
-                (int)(current) / 60, (int)(current) % 60, 
-                (int)(current * 1000) % 1000);
+            return (boost::format("%d:%02d.%03d min.")
+                    % ((int)(current) / 60)
+                    % ((int)(current) % 60)
+                    % ((int)(current * 1000) % 1000)).str();
         }
         else {
             // show seconds
-            sprintf(time_buffer, "%d.%03d sec.", (int)current, 
-                (int)(current * 1000) % 1000);
+            return (boost::format("%d.%03d sec.")
+                    % (int)current
+                    % ((int)(current * 1000) % 1000)).str();
         }
-        return time_buffer;
     }
 };
 


### PR DESCRIPTION
There have been compiler warnings about `sprintf` usage for some time, and now we have a bug report as well (#145). I replaced them mostly with `boost::format` but in one case with `std::to_string` (our second use of a C++11 feature!).

I also did a few cleanups while I was in the code - indentation and one unused header.