### PR TITLE
Fix various warnings

### DIFF
--- a/include/boost/wave/grammars/cpp_chlit_grammar.hpp
+++ b/include/boost/wave/grammars/cpp_chlit_grammar.hpp
@@ -166,7 +166,7 @@ struct chlit_grammar :
 
             // the rule for a character literal
             ch_lit
-                =   eps_p[self.value = phx::val(0), self.long_lit = phx::val(false)]
+                =   eps_p[(self.value = phx::val(0), self.long_lit = phx::val(false))]
                     >> !ch_p('L')[self.long_lit = phx::val(true)]
                     >>  ch_p('\'')
                     >> +(   (

--- a/include/boost/wave/grammars/cpp_intlit_grammar.hpp
+++ b/include/boost/wave/grammars/cpp_intlit_grammar.hpp
@@ -101,16 +101,16 @@ struct intlit_grammar :
                             (ch_p('X') | ch_p('x'))
                         >>  uint_parser<uint_literal_type, 16>()
                             [
-                                self.val = phx::arg1,
-                                phx::var(self.is_unsigned) = true
+                                (self.val = phx::arg1,
+                                 phx::var(self.is_unsigned) = true)
                             ]
                     ,
 
                     oct_lit =
                        !uint_parser<uint_literal_type, 8>()
                         [
-                            self.val = phx::arg1,
-                            phx::var(self.is_unsigned) = true
+                            (self.val = phx::arg1,
+                             phx::var(self.is_unsigned) = true)
                         ]
                     ,
 

--- a/include/boost/wave/token_ids.hpp
+++ b/include/boost/wave/token_ids.hpp
@@ -14,6 +14,7 @@
 #define BOOST_TOKEN_IDS_HPP_414E9A58_F079_4789_8AFF_513815CE475B_INCLUDED
 
 #include <string>
+#include <cstdint>
 
 #include <boost/wave/wave_config.hpp>
 
@@ -43,7 +44,7 @@ namespace wave {
 
 ///////////////////////////////////////////////////////////////////////////////
 //  the token_category helps to classify the different token types
-enum token_category {
+enum token_category : std::uint32_t {
     IdentifierTokenType         = 0x08040000,
     ParameterTokenType          = 0x08840000,
     ExtParameterTokenType       = 0x088C0000,
@@ -78,7 +79,7 @@ enum token_category {
 
 ///////////////////////////////////////////////////////////////////////////////
 //  the token_id assigns unique numbers to the different C++ lexemes
-enum token_id {
+enum token_id : std::uint32_t {
     T_UNKNOWN      = 0,
     T_FIRST_TOKEN  = 256,
     T_AND          = TOKEN_FROM_ID(T_FIRST_TOKEN, OperatorTokenType),
@@ -328,6 +329,26 @@ enum token_id {
     T_EXTPARAMETERBASE = TOKEN_FROM_ID(T_LAST_TOKEN+4, ExtParameterTokenType),
     T_OPTPARAMETERBASE = TOKEN_FROM_ID(T_LAST_TOKEN+4, OptParameterTokenType)
 };
+
+///////////////////////////////////////////////////////////////////////////////
+//  token_category and token_id may be used together
+constexpr token_id operator&(token_id a, token_category b)
+{
+    return static_cast<token_id>(
+        static_cast<std::uint32_t>(a) & static_cast<std::uint32_t>(b));
+}
+
+constexpr token_id operator|(token_id a, token_category b)
+{
+    return static_cast<token_id>(
+        static_cast<std::uint32_t>(a) | static_cast<std::uint32_t>(b));
+}
+
+constexpr bool operator==(token_category a, token_id b)
+{
+    return static_cast<std::uint32_t>(a) == static_cast<std::uint32_t>(b);
+}
+
 
 ///////////////////////////////////////////////////////////////////////////////
 //  redefine the TOKEN_FROM_ID macro to be more type safe

--- a/tool/trace_macro_expansion.hpp
+++ b/tool/trace_macro_expansion.hpp
@@ -1260,8 +1260,9 @@ protected:
 
         if (0 == values.size()) return false;   // ill_formed_pragma_option
 
-        string_type stdout_file(std::tmpnam(0));
-        string_type stderr_file(std::tmpnam(0));
+        namespace fs = boost::filesystem;
+        string_type stdout_file = (fs::temp_directory_path() / fs::unique_path()).native().c_str();
+        string_type stderr_file = (fs::temp_directory_path() / fs::unique_path()).native().c_str();
         string_type system_str(boost::wave::util::impl::as_string(values));
         string_type native_cmd(system_str);
 


### PR DESCRIPTION
Address the following issues:

1. comma operator inside square brackets (used in Phoenix expressions) is deprecated as of C++20
2. different typed enums need some extra help to be "interoperable" (for arithmetic)
3. Replace `tmpnam` calls with safer Boost.Filesystem features

These are flagged by Clang (1 and 2) or the linker (3).

Merging this PR will resolve #135 and #147 