### PR TITLE
MSVC-related cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Boost.Wave
 
-Branch   | Travis
----------|--------
-Develop  | [![Build Status](https://travis-ci.org/boostorg/wave.svg?branch=develop)](https://travis-ci.org/boostorg/wave)
-Master   | [![Build Status](https://travis-ci.org/boostorg/wave.svg?branch=master)](https://travis-ci.org/boostorg/wave)
+Branch   | Appveyor (MSVC) | GitHub Actions (gcc, clang) |
+---------|-----------------|-----------------------------|
+Master   | [![AppVeyor](https://ci.appveyor.com/api/projects/status/3v74vuhk8dwt2wr9/branch/master?svg=true)](https://ci.appveyor.com/project/jefftrull/wave/branch/master) | [![GitHub Actions](https://github.com/boostorg/wave/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/boostorg/wave/actions?query=branch%3Amaster) |
+Develop   | [![AppVeyor](https://ci.appveyor.com/api/projects/status/3v74vuhk8dwt2wr9/branch/develop?svg=true)](https://ci.appveyor.com/project/jefftrull/wave/branch/develop) | [![GitHub Actions](https://github.com/boostorg/wave/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/boostorg/wave/actions?query=branch%3Adevelop) |
 
 The Wave C++ preprocessor library is a Standards conformant implementation of the mandated C99/C++ preprocessor functionality packed behind a simple to use interface, which integrates well with the well known idioms of the Standard Template Library (STL).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,9 +16,6 @@ branches:
 environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      TOOLSET: msvc-9.0,msvc-10.0,msvc-11.0,msvc-12.0
-      ADDRMD: 32
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       TOOLSET: msvc-14.0
       ADDRMD: 32,64
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ branches:
     - master
     - develop
     - /feature\/.*/
+    - /bugfix\/.*/
 
 environment:
   matrix:

--- a/include/boost/wave/util/cpp_macromap.hpp
+++ b/include/boost/wave/util/cpp_macromap.hpp
@@ -14,7 +14,6 @@
 #define BOOST_CPP_MACROMAP_HPP_CB8F51B0_A3F0_411C_AEF4_6FF631B8B414_INCLUDED
 
 #include <cstdlib>
-#include <cstdio>
 #include <ctime>
 
 #include <list>
@@ -23,6 +22,7 @@
 #include <vector>
 #include <iterator>
 #include <algorithm>
+#include <string>
 
 #include <boost/assert.hpp>
 #include <boost/wave/wave_config.hpp>
@@ -1701,11 +1701,8 @@ macromap<ContextT>::expand_predefined_macro(token_type const &curr_token,
     }
     else if (value == "__INCLUDE_LEVEL__") {
         // expand the __INCLUDE_LEVEL__ macro
-        char buffer[22]; // 21 bytes holds all NUL-terminated unsigned 64-bit numbers
-
-        using namespace std;    // for some systems sprintf is in namespace std
-        sprintf(buffer, "%d", (int)ctx.get_iteration_depth());
-        replacement = token_type(T_INTLIT, buffer, curr_token.get_position());
+        std::string buffer = std::to_string(ctx.get_iteration_depth());
+        replacement = token_type(T_INTLIT, buffer.c_str(), curr_token.get_position());
     }
 
     // post-expansion hooks

--- a/include/boost/wave/util/cpp_macromap_predef.hpp
+++ b/include/boost/wave/util/cpp_macromap_predef.hpp
@@ -17,9 +17,6 @@
 #include <boost/assert.hpp>
 #include <boost/format.hpp>
 
-#include <boost/chrono/io/timezone.hpp>
-#include <boost/chrono/io/time_point_io.hpp>
-
 #include <boost/wave/wave_config.hpp>
 #include <boost/wave/wave_config_constant.hpp>
 #include <boost/wave/token_ids.hpp>
@@ -80,20 +77,47 @@ namespace util {
     protected:
         void reset_datestr()
         {
-            std::stringstream datestream;
-            using namespace boost::chrono;
-            // format as abbreviated (3 letter for en-us) month, day, 4-number year:
-            datestream << time_fmt(timezone::local, "\"%b %d %Y\"") << system_clock::now();
-            datestr_ = strconv(datestream.str());
+            static const char *const monthnames[] = {
+                "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+            };
+
+            // for some systems sprintf, time_t etc. is in namespace std
+            using namespace std;
+
+            time_t tt = time(0);
+            struct tm *tb = 0;
+
+            if (tt != (time_t)-1) {
+                tb = localtime (&tt);
+                datestr_ = strconv((boost::format("\"%s %2d %4d\"")
+                                    % monthnames[tb->tm_mon]
+                                    % tb->tm_mday
+                                    % (tb->tm_year + 1900)).str());
+            }
+            else {
+                datestr_ = "\"??? ?? ????\"";
+            }
         }
 
         void reset_timestr()
         {
-            std::stringstream timestream;
-            using namespace boost::chrono;
-            // format time as HH:MM:SS
-            timestream << time_fmt(timezone::local, "\"%T\"") << system_clock::now();
-            timestr_ = strconv(timestream.str());
+            // for some systems sprintf, time_t etc. is in namespace std
+            using namespace std;
+
+            time_t tt = time(0);
+            struct tm *tb = 0;
+
+            if (tt != (time_t)-1) {
+                tb = localtime (&tt);
+                timestr_ = strconv((boost::format("\"%02d:%02d:%02d\"")
+                                    % tb->tm_hour
+                                    % tb->tm_min
+                                    % tb->tm_sec).str());
+            }
+            else {
+                timestr_ = "\"??:??:??\"";
+            }
         }
 
         void reset_version()

--- a/include/boost/wave/util/cpp_macromap_predef.hpp
+++ b/include/boost/wave/util/cpp_macromap_predef.hpp
@@ -17,6 +17,9 @@
 #include <boost/assert.hpp>
 #include <boost/format.hpp>
 
+#include <boost/chrono/io/timezone.hpp>
+#include <boost/chrono/io/time_point_io.hpp>
+
 #include <boost/wave/wave_config.hpp>
 #include <boost/wave/wave_config_constant.hpp>
 #include <boost/wave/token_ids.hpp>
@@ -77,47 +80,20 @@ namespace util {
     protected:
         void reset_datestr()
         {
-            static const char *const monthnames[] = {
-                "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
-            };
-
-            // for some systems sprintf, time_t etc. is in namespace std
-            using namespace std;
-
-            time_t tt = time(0);
-            struct tm *tb = 0;
-
-            if (tt != (time_t)-1) {
-                tb = localtime (&tt);
-                datestr_ = strconv((boost::format("\"%s %2d %4d\"")
-                                    % monthnames[tb->tm_mon]
-                                    % tb->tm_mday
-                                    % (tb->tm_year + 1900)).str());
-            }
-            else {
-                datestr_ = "\"??? ?? ????\"";
-            }
+            std::stringstream datestream;
+            using namespace boost::chrono;
+            // format as abbreviated (3 letter for en-us) month, day, 4-number year:
+            datestream << time_fmt(timezone::local, "\"%b %d %Y\"") << system_clock::now();
+            datestr_ = strconv(datestream.str());
         }
 
         void reset_timestr()
         {
-            // for some systems sprintf, time_t etc. is in namespace std
-            using namespace std;
-
-            time_t tt = time(0);
-            struct tm *tb = 0;
-
-            if (tt != (time_t)-1) {
-                tb = localtime (&tt);
-                timestr_ = strconv((boost::format("\"%02d:%02d:%02d\"")
-                                    % tb->tm_hour
-                                    % tb->tm_min
-                                    % tb->tm_sec).str());
-            }
-            else {
-                timestr_ = "\"??:??:??\"";
-            }
+            std::stringstream timestream;
+            using namespace boost::chrono;
+            // format time as HH:MM:SS
+            timestream << time_fmt(timezone::local, "\"%T\"") << system_clock::now();
+            timestr_ = strconv(timestream.str());
         }
 
         void reset_version()

--- a/include/boost/wave/util/iteration_context.hpp
+++ b/include/boost/wave/util/iteration_context.hpp
@@ -12,8 +12,8 @@
 #define BOOST_ITERATION_CONTEXT_HPP_9556CD16_F11E_4ADC_AC8B_FB9A174BE664_INCLUDED
 
 #include <cstdlib>
-#include <cstdio>
 #include <stack>
+#include <string>
 
 #include <boost/wave/wave_config.hpp>
 #include <boost/wave/cpp_exceptions.hpp>
@@ -55,12 +55,9 @@ public:
         typename base_type::value_type const &val)
     {
         if (iter_ctx.size() == max_include_nesting_depth) {
-        char buffer[22];    // 21 bytes holds all NUL-terminated unsigned 64-bit numbers
-
-            using namespace std;    // for some systems sprintf is in namespace std
-            sprintf(buffer, "%d", (int)max_include_nesting_depth);
+            std::string buffer = std::to_string(max_include_nesting_depth);
             BOOST_WAVE_THROW_CTX(ctx, preprocess_exception,
-                include_nesting_too_deep, buffer, pos);
+                                 include_nesting_too_deep, buffer.c_str(), pos);
         }
         iter_ctx.push(val);
     }

--- a/samples/list_includes/lexertl/lexertl_lexer.hpp
+++ b/samples/list_includes/lexertl/lexertl_lexer.hpp
@@ -13,6 +13,7 @@
 #include <fstream>
 
 #include <boost/iterator/iterator_traits.hpp>
+#include <boost/format.hpp>
 
 #include <boost/wave/wave_config.hpp>
 #include <boost/wave/language_support.hpp>
@@ -773,15 +774,11 @@ public:
                     case T_ANYCTRL:
                         // matched some unexpected character
                         {
-                            // 21 is the max required size for a 64 bit integer
-                            // represented as a string
-                            char buffer[22];
                             string_type msg("invalid character in input stream: '0x");
 
-                            // for some systems sprintf is in namespace std
-                            using namespace std;
-                            sprintf(buffer, "%02x'", token_val[0]);
-                            msg += buffer;
+                            std::string buffer = (boost::format("%02x'") % token_val[0]).str();
+
+                            msg += buffer.c_str();
                             BOOST_WAVE_LEXER_THROW(
                                 wave::cpplexer::lexing_exception,
                                 generic_lexing_error,

--- a/tool/trace_macro_expansion.hpp
+++ b/tool/trace_macro_expansion.hpp
@@ -10,7 +10,6 @@
 #if !defined(BOOST_TRACE_MACRO_EXPANSION_HPP_D8469318_8407_4B9D_A19F_13CA60C1661F_INCLUDED)
 #define BOOST_TRACE_MACRO_EXPANSION_HPP_D8469318_8407_4B9D_A19F_13CA60C1661F_INCLUDED
 
-#include <cstdio>
 #include <cstdlib>
 #include <ctime>
 
@@ -572,16 +571,11 @@ public:
         pos.set_column(column);      // account for '#line'
         pending.push_back(result_type(T_SPACE, " ", pos));
 
-        // 21 is the max required size for a 64 bit integer represented as a
-        // string
-        char buffer[22];
-
-        using namespace std;    // for some systems sprintf is in namespace std
-        sprintf (buffer, "%zd", pos.get_line());
+        std::string lineno = std::to_string(pos.get_line());
 
         pos.set_column(++column);                 // account for ' '
-        pending.push_back(result_type(T_INTLIT, buffer, pos));
-        pos.set_column(column += (unsigned int)strlen(buffer)); // account for <number>
+        pending.push_back(result_type(T_INTLIT, lineno.c_str(), pos));
+        pos.set_column(column += (unsigned int)lineno.size()); // account for <number>
         pending.push_back(result_type(T_SPACE, " ", pos));
         pos.set_column(++column);                 // account for ' '
 


### PR DESCRIPTION
1. Remove some additional calls to sprintf() via Boost.Format and std::to_string to silence warnings
2. Remove Appveyor C++03 configurations
3. Update build "badge" to reflect Github Actions and Appveyor, instead of Travis (now unused)