### PR TITLE
Update ChangeLog for 1.79 bugfixes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,12 @@ CHANGELOG
 
 Boost V1.79:
   - Removed support for C++03 (as a compiler) - previously deprecated in 1.74
+  - Fixed #135: Comma operators in array subscripts are deprecated in C++20
+  - Fixed #137: Simple unknown directive => found_unknown_directive is not called, stripped of pound.
+  - Fixed #138: Empty ifdef block does not emit line directive for missing whitespace
+  - Fixed #143: Parsing __has_include() fails with trailing tokens
+  - Fixed #145: Sanitizer complains about reset_version()
+  - Fixed #147: bitwise operations between different enumeration types are deprecated
 
 Boost V1.75:
   - Introduced C++20 tokens, including the spaceship operator


### PR DESCRIPTION
The 1.79 release window is approaching. I don't know whether we'll get anything else done in time for code freeze but I've updated the ChangeLog to reflect the latest activity. A merge of develop into master will follow.