### PR TITLE
Add C++11 constexpr requirement

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ branches:
 environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      TOOLSET: msvc-14.0
+      TOOLSET: msvc-12.0,msvc-14.0
       ADDRMD: 32,64
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       TOOLSET: msvc-14.1

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -13,6 +13,7 @@ import ../../config/checks/config : requires ;
 project boost/wave
     : requirements
       [ requires
+        cxx11_constexpr
         cxx11_variadic_templates
         cxx11_rvalue_references
         cxx11_hdr_thread


### PR DESCRIPTION
This is required as of https://github.com/boostorg/wave/blob/develop/build/Jamfile.v2#L15

Add a VS2013 job which would otherwise fail, see #153

Note that VS2013 is NOT supported by Boost.Wave anymore due to incomplete C++11 support. The added requirement makes it skip building Boost.Wave on that (and possibly other affected) compiler(s) avoiding a hard error.