### PR TITLE
Add "cxxstd" json field to the meta json file.

### DIFF
--- a/meta/libraries.json
+++ b/meta/libraries.json
@@ -8,6 +8,7 @@
     "category": [
         "String"
     ],
+    "cxxstd": "11",
     "maintainers": [
         "Hartmut Kaiser <hartmut.kaiser -at- gmail.com>"
     ]


### PR DESCRIPTION
See the similar commits from @eldiener, e.g. https://github.com/boostorg/nowide/commit/de9a58d43b9d4bd9b6eae5e69a6da391dadfa625