### PR TITLE
Add the C++11 requirements also to the test project

### DIFF
--- a/test/build/Jamfile.v2
+++ b/test/build/Jamfile.v2
@@ -41,6 +41,15 @@ TESTWAVE_FILES = test.cfg
     ;
 
 project wave/test
+    : requirements
+      [ requires
+        cxx11_constexpr
+        cxx11_variadic_templates
+        cxx11_rvalue_references
+        cxx11_hdr_thread
+        cxx11_hdr_mutex
+        cxx11_hdr_regex
+      ]
     ;
 
 for local source in $(SOURCES)

--- a/test/build/Jamfile.v2
+++ b/test/build/Jamfile.v2
@@ -8,6 +8,7 @@
 # Software License, Version 1.0. (See accompanying file 
 # LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+import config : requires ;
 
 #
 # These are the sources to compile for the testwave application


### PR DESCRIPTION
Followup to https://github.com/boostorg/wave/pull/154

I hope I got this right, doesn't Appveyor run for PRs too?
I was also a bit confused about the "build" subfolder of test which I've seen here for the first time. Wouldn't it be easier to put that into `test/Jamfile` and get rid of the `test/build` folder?

Anyway, check if this makes sense and passes on the updated Appveyor config or if there need to be similar checks elsewhere