### PR TITLE
Clean up C++11 requirements further

### DIFF
--- a/include/boost/wave/wave_config.hpp
+++ b/include/boost/wave/wave_config.hpp
@@ -522,7 +522,8 @@ namespace boost { namespace wave
 
 #if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) || defined(BOOST_NO_CXX11_RVALUE_REFERENCES) \
     || defined(BOOST_NO_CXX11_HDR_THREAD) \
-    || defined(BOOST_NO_CXX11_HDR_MUTEX) || defined(BOOST_NO_CXX11_HDR_REGEX)
+    || defined(BOOST_NO_CXX11_HDR_MUTEX) || defined(BOOST_NO_CXX11_HDR_REGEX) \
+    || defined(BOOST_NO_CXX11_CONSTEXPR)
 
 #error "C++03 support is deprecated in Boost.Wave 1.74 and was removed in Boost.Wave 1.79."
 

--- a/samples/Jamfile.v2
+++ b/samples/Jamfile.v2
@@ -3,8 +3,19 @@
 # (See accompanying file LICENSE_1_0.txt
 # or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+import config : requires ;
+
 project 
-    : requirements <hardcode-dll-paths>true
+    : requirements
+      <hardcode-dll-paths>true
+      [ requires
+        cxx11_constexpr
+        cxx11_variadic_templates
+        cxx11_rvalue_references
+        cxx11_hdr_thread
+        cxx11_hdr_mutex
+        cxx11_hdr_regex
+      ]
     ;
 
 build-project advanced_hooks/build ;


### PR DESCRIPTION
- Test the requirement of "constexpr" for the deprecation error
- Ensure C++11 requirements are checked for the samples build

As @Flamefire noticed, subprojects like "test" and "samples" also need C++11 requirements for their builds to pass (or more accurately, not happen) with C++03 compilers. This adds those requirements for the samples.

This also adds an explicit check on the availability of `constexpr` to the existing deprecation error, so the problem will be more obvious when someone attempts a manual build. It turns out that msvc-12 supports many parts of C++11 but not that one. Going forward we will need to update the check as we use additional C++11 features.