### PR TITLE
Fix warnings about freeing non-heap-allocated object

### DIFF
--- a/include/boost/wave/util/flex_string.hpp
+++ b/include/boost/wave/util/flex_string.hpp
@@ -544,14 +544,6 @@ class AllocatorStringStorage : public A
             static_cast<const char*>(p));
     }
 
-    void* Realloc(void* p, size_type oldSz, size_type newSz)
-    {
-        void* r = Alloc(newSz);
-        flex_string_details::pod_copy(p, p + Min(oldSz, newSz), r);
-        Free(p, oldSz);
-        return r;
-    }
-
     void Free(void* p, size_type sz)
     {
         boost::allocator_deallocate(static_cast<A&>(*this), static_cast<E*>(p), sz);

--- a/include/boost/wave/util/flex_string.hpp
+++ b/include/boost/wave/util/flex_string.hpp
@@ -384,7 +384,7 @@ public:
     ~SimpleStringStorage()
     {
         BOOST_ASSERT(begin() <= end());
-        if (pData_ != &emptyString_) free(pData_);
+        if (capacity() > 0) free(pData_);
     }
 
     iterator begin()
@@ -410,13 +410,14 @@ public:
 
     void reserve(size_type res_arg)
     {
-        if (res_arg <= capacity())
+        size_type cap = capacity();
+        if (res_arg <= cap)
         {
             // @@@ insert shrinkage here if you wish
             return;
         }
 
-        if (pData_ == &emptyString_)
+        if (cap == 0)
         {
             Init(0, res_arg);
         }
@@ -495,7 +496,7 @@ public:
 
     const E* c_str() const
     {
-        if (pData_ != &emptyString_) *pData_->pEnd_ = E();
+        if (capacity() > 0) *pData_->pEnd_ = E();
         return pData_->buffer_;
     }
 
@@ -703,7 +704,7 @@ public:
 
     const E* c_str() const
     {
-        if (pData_ != &SimpleStringStorage<E, A>::emptyString_)
+        if (capacity() > 0)
         {
             *pData_->pEnd_ = E();
         }


### PR DESCRIPTION
This PR makes 3 commits:

- Convert all checks for whether `pData_` points to `emptyString_` to checks for zero `capacity()`. This is a safer check, which should work across shared library boundaries.
- Added compile-time asserts that `pData_` never points to `emptyString_` when `capacity()` is zero. This fixes https://github.com/boostorg/wave/issues/159.
- Removes `AllocatorStringStorage::Realloc`. This function was not used and potentially incorrect, as it would call `Free` on the input buffer, even if it was `emptyString_`.

I did not use `#pragma` to silence the warnings because it seems gcc 11.2 doesn't support disabling this warning (the warnings are still emitted).
