### PR TITLE
Let expanded long integer literals participate in conditional expressions

### DIFF
--- a/include/boost/wave/grammars/cpp_expression_grammar.hpp
+++ b/include/boost/wave/grammars/cpp_expression_grammar.hpp
@@ -573,6 +573,10 @@ struct expression_grammar :
                     [
                         constant.val = impl::as_intlit(arg1)
                     ]
+                |   ch_p(T_LONGINTLIT)
+                    [
+                        constant.val = impl::as_intlit(arg1)
+                    ]
                 |   ch_p(T_CHARLIT)
                     [
                         constant.val = impl::as_chlit(arg1)
@@ -694,6 +698,7 @@ struct expression_grammar :
             constant_nocalc
                 =   ch_p(T_PP_NUMBER)
                 |   ch_p(T_INTLIT)
+                |   ch_p(T_LONGINTLIT)
                 |   ch_p(T_CHARLIT)
                 ;
 

--- a/test/testwave/testfiles/t_5_038.cpp
+++ b/test/testwave/testfiles/t_5_038.cpp
@@ -1,0 +1,25 @@
+/*=============================================================================
+    Boost.Wave: A Standard compliant C++ preprocessor library
+    http://www.boost.org/
+
+    Copyright (c) 2022 Jeff Trull. Distributed under the Boost
+    Software License, Version 1.0. (See accompanying file
+    LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+=============================================================================*/
+
+// Verify that long integer literals from a macro expansion parse correctly
+// This test covers #162
+
+//O --c++11
+//O -DFOO=0x1234567ULL
+#define BAZ (FOO*2UL+1UL)
+#define BAR (BAZ + 1ULL)
+
+#if defined(BAR) && (BAR == 0x2468AD0)
+struct Bar {};
+#else
+#endif
+
+//R #line 20 "t_5_038.cpp"
+//R struct Bar {};

--- a/test/testwave/testfiles/test.cfg
+++ b/test/testwave/testfiles/test.cfg
@@ -144,6 +144,7 @@ t_5_034.cpp
 t_5_035.cpp
 t_5_036.cpp
 t_5_037.cpp
+t_5_038.cpp
 
 #
 # unit tests from the mcpp preprocessor validation suite


### PR DESCRIPTION
It seems that the grammar for conditional preprocessor expressions was not updated when long integer literals were added for C++11. This seems to work most of the time, as they get recognized as `PP_NUMBER` tokens, which are in the grammar. Sometimes, though, when they are produced as part of a macro expansion, they can appear as `LONGINTLIT` tokens, which are _not_ in the grammar. Wave then rejects the expression as invalid.

These changes add `LONGINTLIT` tokens as valid numbers in expressions, and in doing so resolve #162 