### PR TITLE
Use constexpr instead of macros for tokenid constants in samples

### DIFF
--- a/samples/cpp_tokens/slex/cpp_slex_lexer.hpp
+++ b/samples/cpp_tokens/slex/cpp_slex_lexer.hpp
@@ -436,9 +436,9 @@ lexer<IteratorT, PositionT>::init_data_pp_number[INIT_DATA_PP_NUMBER_SIZE] =
 ///////////////////////////////////////////////////////////////////////////////
 // C++11 only token definitions
 
-#define T_EXTCHARLIT      token_id(T_CHARLIT|AltTokenType)
-#define T_EXTSTRINGLIT    token_id(T_STRINGLIT|AltTokenType)
-#define T_EXTRAWSTRINGLIT token_id(T_RAWSTRINGLIT|AltTokenType)
+constexpr token_id T_EXTCHARLIT = T_CHARLIT | AltTokenType;
+constexpr token_id T_EXTSTRINGLIT = T_STRINGLIT | AltTokenType;
+constexpr token_id T_EXTRAWSTRINGLIT = T_RAWSTRINGLIT | AltTokenType;
 
 template <typename IteratorT, typename PositionT>
 typename lexer_base<IteratorT, PositionT>::lexer_data const
@@ -661,6 +661,8 @@ public:
 // get the next token from the input stream
     token_type& get(token_type& result) BOOST_OVERRIDE
     {
+        using namespace cpplexer::slex::lexer;
+
         if (!at_eof) {
             do {
             // generate and return the next token
@@ -802,10 +804,6 @@ private:
 
 template <typename IteratorT, typename PositionT>
 lexer::lexer<IteratorT, PositionT> slex_functor<IteratorT, PositionT>::lexer;
-
-#undef T_EXTCHARLIT
-#undef T_EXTSTRINGLIT
-#undef T_EXTRAWSTRINGLIT
 
 ///////////////////////////////////////////////////////////////////////////////
 //

--- a/samples/list_includes/lexertl/lexertl_lexer.hpp
+++ b/samples/list_includes/lexertl/lexertl_lexer.hpp
@@ -421,9 +421,9 @@ lexertl<Iterator, Position>::init_data_pp_number[INIT_DATA_PP_NUMBER_SIZE] =
 
 // C++11 specific token definitions
 
-#define T_EXTCHARLIT      token_id(T_CHARLIT|AltTokenType)
-#define T_EXTSTRINGLIT    token_id(T_STRINGLIT|AltTokenType)
-#define T_EXTRAWSTRINGLIT token_id(T_RAWSTRINGLIT|AltTokenType)
+constexpr token_id T_EXTCHARLIT = T_CHARLIT | AltTokenType;
+constexpr token_id T_EXTSTRINGLIT = T_STRINGLIT | AltTokenType;
+constexpr token_id T_EXTRAWSTRINGLIT = T_RAWSTRINGLIT | AltTokenType;
 
 template <typename Iterator, typename Position>
 typename lexertl<Iterator, Position>::lexer_data const
@@ -835,10 +835,6 @@ lexer::lexertl<
 #undef INIT_DATA_PP_NUMBER_SIZE
 #undef INIT_MACRO_DATA_SIZE
 #undef T_ANYCTRL
-
-#undef T_EXTCHARLIT
-#undef T_EXTSTRINGLIT
-#undef T_EXTRAWSTRINGLIT
 
 ///////////////////////////////////////////////////////////////////////////////
 //

--- a/samples/token_statistics/xlex/xlex_lexer.hpp
+++ b/samples/token_statistics/xlex/xlex_lexer.hpp
@@ -402,9 +402,9 @@ lexer<Iterator, Position>::init_data_cpp[] =
 
 ///////////////////////////////////////////////////////////////////////////////
 // C++11 only token definitions
-#define T_EXTCHARLIT      token_id(T_CHARLIT|AltTokenType)
-#define T_EXTSTRINGLIT    token_id(T_STRINGLIT|AltTokenType)
-#define T_EXTRAWSTRINGLIT token_id(T_RAWSTRINGLIT|AltTokenType)
+constexpr token_id T_EXTCHARLIT = T_CHARLIT | AltTokenType;
+constexpr token_id T_EXTSTRINGLIT = T_STRINGLIT | AltTokenType;
+constexpr token_id T_EXTRAWSTRINGLIT = T_RAWSTRINGLIT | AltTokenType;
 
 template <typename Iterator, typename Position>
 typename lexer<Iterator, Position>::lexer_data const
@@ -479,9 +479,6 @@ lexer<Iterator, Position>::init_data_cpp2a[] =
 #undef TOKEN_DATA
 #undef TOKEN_DATA_EX
 
-#undef T_EXTCHARLIT
-#undef T_EXTSTRINGLIT
-#undef T_EXTRAWSTRINGLIT
 ///////////////////////////////////////////////////////////////////////////////
 // initialize cpp lexer 
 template <typename Iterator, typename Position>


### PR DESCRIPTION
Under Visual Studio 2019 (and possibly earlier), building with `/permissive-` causes three samples to fail to compile. Adding the
`/Zc:twoPhase-` option makes them compile successfully again. See bug #160 for more details.

It's unclear what the source of this issue is, but using `constexpr` variables instead of a macro is better practice anyway, and fixes the errors.