### PR TITLE
Use `boost::allocator_max_size` for `SmallStringOpt` to obtain allocator's max size

### DIFF
--- a/include/boost/wave/util/flex_string.hpp
+++ b/include/boost/wave/util/flex_string.hpp
@@ -995,7 +995,7 @@ public:
     }
 
     size_type max_size() const
-    { return get_allocator().max_size(); }
+    { return boost::allocator_max_size(get_allocator()); }
 
     size_type capacity() const
     { return Small() ? maxSmallString : GetStorage().capacity(); }


### PR DESCRIPTION
Since direct call to `a.max_size()` may fail to compile since C++11.

I found the fix was missing for `SmallStringOpt` when building a project at work in C++20 mode (where `std::allocator`'s `max_size` is removed).

Related to #85, #86, #93.