### PR TITLE
Fix potential buffer overflow, fixes boostorg/wave#175

### DIFF
--- a/include/boost/wave/cpp_exceptions.hpp
+++ b/include/boost/wave/cpp_exceptions.hpp
@@ -393,7 +393,7 @@ public:
     :   preprocess_exception(what_, code, line_, column_, filename_)
     {
         unsigned int off = 0;
-        while (off < sizeof(name) && *macroname)
+        while (off < sizeof(name) - 1 && *macroname)
             name[off++] = *macroname++;
         name[off] = 0;
     }


### PR DESCRIPTION
Protect against an off-by-one write into the static buffer