### PR TITLE
Fix UB in memmove

### DIFF
--- a/include/boost/wave/cpplexer/re2clex/cpp_re.hpp
+++ b/include/boost/wave/cpplexer/re2clex/cpp_re.hpp
@@ -181,7 +181,10 @@ uchar *fill(Scanner<Iterator> *s, uchar *cursor)
         {
             if (NULL == s->lim)
                 s->lim = s->top;
-            memmove(s->bot, s->tok, s->lim - s->tok);
+            size_t length = s->lim - s->tok;
+            if(length > 0){
+                memmove(s->bot, s->tok, length);
+            }
             s->tok = s->cur = s->bot;
             s->ptr -= cnt;
             cursor -= cnt;
@@ -202,7 +205,10 @@ uchar *fill(Scanner<Iterator> *s, uchar *cursor)
                 return cursor;
             }
 
-            memmove(buf, s->tok, s->lim - s->tok);
+            size_t length = s->lim - s->tok;
+            if(length > 0){
+                memmove(buf, s->tok, length);
+            }
             s->tok = s->cur = buf;
             s->ptr = &buf[s->ptr - s->bot];
             cursor = &buf[cursor - s->bot];


### PR DESCRIPTION
boost::wave sometimes calls memmove with a nullptr destination and a 0 byte length. This is undefined behavior. This diff adds a check so that memmove is not called if the length is 0