### PR TITLE
Support a single #pragma without body

### DIFF
--- a/include/boost/wave/util/cpp_iterator.hpp
+++ b/include/boost/wave/util/cpp_iterator.hpp
@@ -2427,10 +2427,9 @@ pp_iterator_functor<ContextT>::on_pragma(
     const_tree_iterator_t last = make_ref_transform_iterator(end, get_value);
 
     expanded.push_back(result_type(T_PP_PRAGMA, "#pragma", act_token.get_position()));
-    expanded.push_back(result_type(T_SPACE, " ", act_token.get_position()));
 
-    while (++first != last && IS_CATEGORY(*first, WhiteSpaceTokenType))
-        expanded.push_back(*first);   // skip whitespace
+    while (first != last && IS_CATEGORY(*first, WhiteSpaceTokenType))
+        expanded.push_back(*first++);   // skip whitespace
 
     if (first != last) {
         if (T_IDENTIFIER == token_id(*first) &&
@@ -2456,7 +2455,6 @@ pp_iterator_functor<ContextT>::on_pragma(
 #endif
         }
     }
-    expanded.push_back(result_type(T_NEWLINE, "\n", act_token.get_position()));
 
     // the queues should be empty at this point
     BOOST_ASSERT(unput_queue.empty());

--- a/test/testwave/testfiles/t_2_006.cpp
+++ b/test/testwave/testfiles/t_2_006.cpp
@@ -23,6 +23,10 @@
 //R #line 25 "t_2_006.cpp"
 //R #pragma STDC preprocessed pragma body
 #pragma STDC PRAGMA_BODY
+// also test pragma without a body (allowed per https://eel.is/c++draft/cpp.pragma)
+//R #line 29 "t_2_006.cpp"
+//R #pragma
+#pragma
 
 //H 10: t_2_006.cpp(12): #define
 //H 08: t_2_006.cpp(12): PRAGMA_BODY=preprocessed pragma body
@@ -36,3 +40,4 @@
 //H 01: t_2_006.cpp(12): PRAGMA_BODY
 //H 02: preprocessed pragma body
 //H 03: preprocessed pragma body
+//H 10: t_2_006.cpp(29): #pragma


### PR DESCRIPTION
This approach differs from the initial plan - which just returned when an empty pragma was detected - because we still need to fire pragma hooks.