### PR TITLE
Handle some previously deprecated, now removed, filesystem code

### DIFF
--- a/include/boost/wave/util/filesystem_compatibility.hpp
+++ b/include/boost/wave/util/filesystem_compatibility.hpp
@@ -16,6 +16,7 @@
 #include <boost/version.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/directory.hpp>
 
 namespace boost { namespace wave { namespace util
 {
@@ -205,6 +206,17 @@ namespace boost { namespace wave { namespace util
         if (p.string().empty())
             return true;
         return boost::filesystem::create_directories(p);
+    }
+
+    // starting with Boost 1.85 no_push was renamed to disable_recursion_pending for consistency
+    // with std::filesystem (deprecated some point before that)
+    inline void no_push(boost::filesystem::recursive_directory_iterator & it)
+    {
+#if BOOST_VERSION >= 108400 && BOOST_FILESYSTEM_VERSION >= 3
+        it.disable_recursion_pending();
+#else
+        it.no_push();
+#endif
     }
 }}}
 

--- a/samples/check_macro_naming/check_macro_naming.cpp
+++ b/samples/check_macro_naming/check_macro_naming.cpp
@@ -170,7 +170,7 @@ int main(int argc, char *argv[])
                        exclude_dirs.end(),
                        fs::canonical(it->path())) != exclude_dirs.end())) {
             // skip recursion here
-            it.no_push();
+            boost::wave::util::no_push(it);
         }
     }
 

--- a/samples/waveidl/idl.cpp
+++ b/samples/waveidl/idl.cpp
@@ -15,6 +15,7 @@
 #include <boost/assert.hpp>
 #include <boost/program_options.hpp>
 #include <boost/filesystem/path.hpp>
+#include <boost/wave/util/filesystem_compatibility.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 //  Include Wave itself
@@ -475,7 +476,7 @@ main (int argc, char *argv[])
     // started from. If this exists, treat it as a wave config file
     fs::path filename = boost::wave::util::create_path(argv[0]);
 
-        filename = filename.branch_path() / "waveidl.cfg";
+        filename = boost::wave::util::branch_path(filename) / "waveidl.cfg";
         cmd_line_util::read_config_file_options(filename.string(), 
             desc_overall_cfgfile, vm, true);
 

--- a/tool/cpp.cpp
+++ b/tool/cpp.cpp
@@ -17,7 +17,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 // Include additional Boost libraries
 #include <boost/filesystem/path.hpp>
-#include <boost/filesystem/convenience.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/timer/timer.hpp>
 #include <boost/any.hpp>

--- a/tool/trace_macro_expansion.hpp
+++ b/tool/trace_macro_expansion.hpp
@@ -22,7 +22,6 @@
 #include <boost/config.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/convenience.hpp>
 
 #include <boost/wave/token_ids.hpp>
 #include <boost/wave/util/macro_helpers.hpp>


### PR DESCRIPTION
Boost.Filesystem just made some changes in its develop branch (one header and two methods removed) and as a result,  Wave is failing CI in develop. This PR makes appropriate adjustments.

