### PR TITLE
Update marker before and after fill() operation in cpplexer

### DIFF
--- a/include/boost/wave/cpplexer/re2clex/cpp_re.hpp
+++ b/include/boost/wave/cpplexer/re2clex/cpp_re.hpp
@@ -38,8 +38,10 @@
 #define YYMARKER  marker
 #define YYFILL(n)                                                             \
     {                                                                         \
+        s->ptr = marker;                                                      \
         cursor = uchar_wrapper(fill(s, cursor), cursor.column);               \
         limit = uchar_wrapper (s->lim);                                       \
+        marker = s->ptr;                                                      \
     }                                                                         \
     /**/
 

--- a/include/boost/wave/cpplexer/re2clex/cpp_re.hpp
+++ b/include/boost/wave/cpplexer/re2clex/cpp_re.hpp
@@ -41,7 +41,7 @@
         s->ptr = marker;                                                      \
         cursor = uchar_wrapper(fill(s, cursor), cursor.column);               \
         limit = uchar_wrapper (s->lim);                                       \
-        marker = s->ptr;                                                      \
+        marker = uchar_wrapper(s->ptr);                                       \
     }                                                                         \
     /**/
 

--- a/include/boost/wave/cpplexer/re2clex/cpp_re.hpp
+++ b/include/boost/wave/cpplexer/re2clex/cpp_re.hpp
@@ -18,6 +18,8 @@
 #include <boost/wave/wave_config.hpp>
 #include <boost/wave/token_ids.hpp>
 #include <boost/wave/cpplexer/cpplexer_exceptions.hpp>
+#include <boost/wave/cpplexer/re2clex/aq.hpp>
+#include <boost/wave/cpplexer/re2clex/scanner.hpp>
 
 // this must occur after all of the includes and before any code appears
 #ifdef BOOST_HAS_ABI_HEADERS
@@ -343,7 +345,6 @@ uchar *fill(Scanner<Iterator> *s, uchar *cursor)
     }
     return cursor;
 }
-#undef BOOST_WAVE_BSIZE
 
 ///////////////////////////////////////////////////////////////////////////////
 //  Special wrapper class holding the current cursor position

--- a/test/build/Jamfile.v2
+++ b/test/build/Jamfile.v2
@@ -243,5 +243,14 @@ test-suite wave
                 /boost/thread//boost_thread
                 /boost/filesystem//boost_filesystem
         ]
+
+        [
+            run
+            # sources
+                ../testwave/fill_boundary.cpp
+                /boost/wave//boost_wave
+                /boost/thread//boost_thread
+                /boost/filesystem//boost_filesystem
+        ]
     ;
 

--- a/test/testwave/fill_boundary.cpp
+++ b/test/testwave/fill_boundary.cpp
@@ -32,8 +32,13 @@ int main() {
 
     // construct input with a trigraph in a tricky spot
     constexpr std::size_t space_count = BOOST_WAVE_BSIZE - 18;
-    auto inp_txt = std::string(space_count, ' ') + ";" + std::string("??=") +
-        "                  auto foo = bar;\n";
+    auto inp_txt = std::string(space_count, ' ') + ";";
+    // add in pound trigraph one character at a time
+    // otherwise, the string literal may get translated by the compiler
+    inp_txt.push_back('?');
+    inp_txt.push_back('?');
+    inp_txt.push_back('=');
+    inp_txt += "                  auto foo = bar;\n";
 
     ctx_t ctx( inp_txt.begin(), inp_txt.end(), "longfile.cpp" );
 

--- a/test/testwave/fill_boundary.cpp
+++ b/test/testwave/fill_boundary.cpp
@@ -35,7 +35,7 @@ int main() {
     auto inp_txt = std::string(space_count, ' ') + ";" + std::string("??=") +
         "                  auto foo = bar;\n";
 
-    auto ctx =  ctx_t( inp_txt.begin(), inp_txt.end(), "longfile.cpp" );
+    ctx_t ctx( inp_txt.begin(), inp_txt.end(), "longfile.cpp" );
 
     auto it = ctx.begin();
 

--- a/test/testwave/fill_boundary.cpp
+++ b/test/testwave/fill_boundary.cpp
@@ -1,0 +1,69 @@
+// Copyright 2024 Jeff Trull.
+//
+// Distributed under the Boost Software License, Version 1.0.
+//
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+
+// There are some tricky corner cases that occur when Wave handles large inputs.
+// Tokens at, near, or crossing the boundary at which a "fill" occurs can
+// interact in unexpected ways. This test is intended to increase code
+// coverage for such situations.
+
+#include <boost/wave/cpplexer/re2clex/cpp_re.hpp>   // for BOOST_WAVE_BSIZE
+
+#include <boost/wave.hpp>
+#include <boost/wave/token_ids.hpp>
+#include <boost/wave/cpplexer/cpp_lex_token.hpp>
+#include <boost/wave/cpplexer/cpp_lex_iterator.hpp>
+
+#include <string>
+
+using token_t = boost::wave::cpplexer::lex_token<>;
+using lex_iter_t = boost::wave::cpplexer::lex_iterator<token_t>;
+using ctx_t = boost::wave::context<
+    std::string::iterator, lex_iter_t,
+    boost::wave::iteration_context_policies::load_file_to_string,
+    boost::wave::context_policies::default_preprocessing_hooks>;
+
+
+int main() {
+    using namespace boost::wave;
+
+    // construct input with a trigraph in a tricky spot
+    constexpr std::size_t space_count = BOOST_WAVE_BSIZE - 18;
+    auto inp_txt = std::string(space_count, ' ') + ";" + std::string("??=") +
+        "                  auto foo = bar;\n";
+
+    auto ctx =  ctx_t( inp_txt.begin(), inp_txt.end(), "longfile.cpp" );
+
+    auto it = ctx.begin();
+
+    if (token_id(*it) != T_SPACE)
+        return 1;
+
+    if (it->get_value().size() != space_count)
+        return 2;
+
+    ++it;
+
+    if (token_id(*it) != T_SEMICOLON)
+        return 3;
+
+    ++it;
+
+    if (token_id(*it) != T_POUND_TRIGRAPH)
+        return 4;
+
+    ++it;
+
+    if (token_id(*it) != T_SPACE)
+        return 5;
+
+    ++it;
+
+    if (token_id(*it) != T_AUTO)
+        return 6;
+
+    return 0;
+}


### PR DESCRIPTION
I think this change is in line with how s->ptr and marker are expected to interact.

This is in reference to:
https://github.com/boostorg/wave/issues/202
