### PR TITLE
Use correct string constructor for non-null-terminated range

### DIFF
--- a/include/boost/wave/cpplexer/re2clex/cpp_re2c_lexer.hpp
+++ b/include/boost/wave/cpplexer/re2clex/cpp_re2c_lexer.hpp
@@ -273,7 +273,8 @@ lexer<IteratorT, PositionT, TokenT>::get(TokenT& result)
     case T_ANY_TRIGRAPH:
         if (boost::wave::need_convert_trigraphs(language)) {
             value = impl::convert_trigraph(
-                string_type((char const *)scanner.tok));
+                string_type((char const *)scanner.tok,
+                            scanner.cur-scanner.tok));
         }
         else {
             value = string_type((char const *)scanner.tok,


### PR DESCRIPTION
There is no guarantee (indeed, it is unlikely) that data within the scanner buffer will be null terminated and so the constructor that accepts a pointer and a count is appropriate.

This is one of the issues revealed by the `BOOST_WAVE_BSIZE` variation experiment