### PR TITLE
Fixes for escaped newline handling

### DIFF
--- a/include/boost/wave/cpplexer/re2clex/cpp_re.hpp
+++ b/include/boost/wave/cpplexer/re2clex/cpp_re.hpp
@@ -238,7 +238,7 @@ uchar *fill(Scanner<Iterator> *s, uchar *cursor)
         for (p = std::max(s->lim - 3, s->cur); p < s->lim + cnt - 2; ++p)
         {
             int len = 0;
-            if (is_backslash(p, s->lim + cnt, len))
+            if (is_backslash(p, s->lim + cnt, len) && ((p + len) < (s->lim + cnt)))
             {
                 if (*(p+len) == '\n')
                 {
@@ -250,7 +250,7 @@ uchar *fill(Scanner<Iterator> *s, uchar *cursor)
                 }
                 else if (*(p+len) == '\r')
                 {
-                    if (*(p+len+1) == '\n')
+                    if (((p + len + 1) < s->lim + cnt) && (*(p+len+1) == '\n'))
                     {
                         int offset = len + 2;
                         memmove(p, p + offset, s->lim + cnt - p - offset);

--- a/include/boost/wave/cpplexer/re2clex/cpp_re.hpp
+++ b/include/boost/wave/cpplexer/re2clex/cpp_re.hpp
@@ -235,9 +235,12 @@ uchar *fill(Scanner<Iterator> *s, uchar *cursor)
         /* backslash-newline erasing time */
 
         /* first scan for backslash-newline and erase them */
-        for (p = std::max(s->lim - 3, s->cur); p < s->lim + cnt - 2; ++p)
+        /* a backslash-newline combination can be 2 (regular) or 4 (trigraph backslash) chars */
+        /* start checking 3 chars within the old buffer, if possible */
+        for (p = (std::max)(s->lim - 3, s->cur); p < s->lim + cnt - 2; ++p)
         {
             int len = 0;
+            /* is there a backslash, and room afterwards for a newline? */
             if (is_backslash(p, s->lim + cnt, len) && ((p + len) < (s->lim + cnt)))
             {
                 if (*(p+len) == '\n')
@@ -250,6 +253,7 @@ uchar *fill(Scanner<Iterator> *s, uchar *cursor)
                 }
                 else if (*(p+len) == '\r')
                 {
+                    /* is there also room for a newline, and is one present? */
                     if (((p + len + 1) < s->lim + cnt) && (*(p+len+1) == '\n'))
                     {
                         int offset = len + 2;

--- a/include/boost/wave/cpplexer/re2clex/cpp_re.hpp
+++ b/include/boost/wave/cpplexer/re2clex/cpp_re.hpp
@@ -235,7 +235,7 @@ uchar *fill(Scanner<Iterator> *s, uchar *cursor)
         /* backslash-newline erasing time */
 
         /* first scan for backslash-newline and erase them */
-        for (p = s->lim; p < s->lim + cnt - 2; ++p)
+        for (p = std::max(s->lim - 3, s->cur); p < s->lim + cnt - 2; ++p)
         {
             int len = 0;
             if (is_backslash(p, s->lim + cnt, len))


### PR DESCRIPTION
Experiments with `BOOST_WAVE_BSIZE` revealed that we were missing some backslash+newline cases, and in others, testing invalid memory locations for the presence of a newline.

These fixes repair the specific issues found but a more general solution is probably in order (and will be particularly needed given the more lenient treatment of newline escapes in C++23)