### PR TITLE
Fix checks for signed overflow

### DIFF
--- a/include/boost/wave/grammars/cpp_expression_value.hpp
+++ b/include/boost/wave/grammars/cpp_expression_value.hpp
@@ -15,6 +15,8 @@
 #include <iostream>
 #endif // defined(BOOST_SPIRIT_DEBUG)
 
+#include <limits>
+
 #include <boost/wave/wave_config.hpp>
 #include <boost/wave/grammars/cpp_value_error.hpp> // value_error
 
@@ -185,28 +187,30 @@ public:
             switch(rhs.type) {
             case is_bool:
                 {
-                    int_literal_type result = value.i + as_long(rhs);
-                    if ((rhs.value.i > 0L && value.i > result) ||
-                        (rhs.value.i < 0L && value.i < result))
+                    // bool is either 0 or 1
+                    if (((std::numeric_limits<int_literal_type>::max)() - as_long(rhs)) < value.i)
                     {
+                        // signed overflow will occur if addition performed
                         valid = error_integer_overflow;
                     }
                     else {
-                        value.i = result;
+                        value.i += as_long(rhs);
                     }
                 }
                 break;
 
             case is_int:
                 {
-                    int_literal_type result = value.i + rhs.value.i;
-                    if ((rhs.value.i > 0L && value.i > result) ||
-                        (rhs.value.i < 0L && value.i < result))
+                    if (((rhs.value.i > 0) &&
+                         (((std::numeric_limits<int_literal_type>::max)() - rhs.value.i) < value.i)) ||
+                        ((rhs.value.i < 0) &&
+                         (((std::numeric_limits<int_literal_type>::min)() - rhs.value.i) > value.i)))
                     {
+                        // signed overflow will occur if addition performed
                         valid = error_integer_overflow;
                     }
                     else {
-                        value.i = result;
+                        value.i += rhs.value.i;
                     }
                 }
                 break;
@@ -252,28 +256,29 @@ public:
             switch(rhs.type) {
             case is_bool:
                 {
-                    int_literal_type result = value.i - as_long(rhs);
-                    if ((rhs.value.i > 0L && result > value.i) ||
-                        (rhs.value.i < 0L && result < value.i))
+                    if (((std::numeric_limits<int_literal_type>::min)() + as_long(rhs)) > value.i)
                     {
+                        // signed overflow will occur if subtraction performed
                         valid = error_integer_overflow;
                     }
                     else {
-                        value.i = result;
+                        value.i -= as_long(rhs);
                     }
                 }
                 break;
 
             case is_int:
                 {
-                    int_literal_type result = value.i - rhs.value.i;
-                    if ((rhs.value.i > 0L && result > value.i) ||
-                        (rhs.value.i < 0L && result < value.i))
+                    if (((rhs.value.i < 0) &&
+                         (((std::numeric_limits<int_literal_type>::max)() + rhs.value.i) < value.i)) ||
+                        ((rhs.value.i > 0) &&
+                         (((std::numeric_limits<int_literal_type>::min)() + rhs.value.i) > value.i)))
                     {
+                        // signed overflow will occur if subtraction performed
                         valid = error_integer_overflow;
                     }
                     else {
-                        value.i = result;
+                        value.i -= rhs.value.i;
                     }
                 }
                 break;
@@ -351,16 +356,22 @@ public:
             case is_bool:   value.i *= as_long(rhs); break;
             case is_int:
                 {
-                    int_literal_type result = value.i * rhs.value.i;
-                    if (0 != value.i && 0 != rhs.value.i &&
-                        (result / value.i != rhs.value.i ||
-                         result / rhs.value.i != value.i)
-                       )
+                    // overflow tests for signed multiplication taken from
+                    // Warren, Hacker's Delight, 2nd Ed. p32
+                    int_literal_type mx = (std::numeric_limits<int_literal_type>::max)();
+                    int_literal_type mn = (std::numeric_limits<int_literal_type>::min)();
+
+                    bool ovflw =
+                        (value.i > 0) ? ((rhs.value.i > 0) ? (value.i > (mx / rhs.value.i))
+                                                           : (rhs.value.i < (mn / value.i)))
+                                      : ((rhs.value.i > 0) ? (value.i < (mn / rhs.value.i))
+                                                           : ((value.i != 0) && (rhs.value.i < (mx / value.i))));
+                    if (ovflw)
                     {
                         valid = error_integer_overflow;
                     }
                     else {
-                        value.i = result;
+                        value.i *= rhs.value.i;
                     }
                 }
                 break;
@@ -430,7 +441,8 @@ public:
             case is_bool:
             case is_int:
                 if (as_long(rhs) != 0) {
-                    if (value.i == -value.i && -1 == rhs.value.i) {
+                    if (std::numeric_limits<int_literal_type>::min() == value.i &&
+                        -1 == rhs.value.i) {
                         // LONG_MIN / -1 on two's complement
                         valid = error_integer_overflow;
                     }

--- a/test/testwave/testfiles/t_6_070.cpp
+++ b/test/testwave/testfiles/t_6_070.cpp
@@ -1,0 +1,21 @@
+/*=============================================================================
+    Boost.Wave: A Standard compliant C++ preprocessor library
+    http://www.boost.org/
+
+    Copyright (c) 2001-2012 Hartmut Kaiser. Distributed under the Boost
+    Software License, Version 1.0. (See accompanying file
+    LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+    The tests included in this file were initially taken from the mcpp V2.5
+    preprocessor validation suite and were modified to fit into the Boost.Wave
+    unit test requirements.
+    The original files of the mcpp preprocessor are distributed under the
+    license reproduced at the end of this file.
+=============================================================================*/
+
+// Tests error reporting: overflow of constant expression in #if directive.
+
+// 14.10:
+//E t_6_070.cpp(20): error: integer overflow in preprocessor expression: $E(__TESTWAVE_LONG_MIN__) / - 1
+#if __TESTWAVE_LONG_MIN__ / - 1
+#endif

--- a/test/testwave/testfiles/test.cfg
+++ b/test/testwave/testfiles/test.cfg
@@ -220,6 +220,7 @@ t_6_066.cpp
 t_6_067.cpp
 t_6_068.cpp
 t_6_069.cpp
+t_6_070.cpp
 
 #
 # t_7: C++0x testing


### PR DESCRIPTION
When verifying that code being preprocessed does not invoke undefined behavior, Wave does it itself.
This change performs tests on the operands in advance, instead.

Tests `t_6_15`, `t_6_17`, and `t_6_18` (though not `t_6_17`, for some reason) signal errors in the absence of this fix with `-fsanitize=signed-integer-overflow` configured, but it does not cause the tests to fail, because these tests are expected to exit with an error anyway.

If merged, this will fix #197 