### PR TITLE
Use vsnprintf instead of vsprintf

### DIFF
--- a/include/boost/wave/cpplexer/re2clex/cpp_re2c_lexer.hpp
+++ b/include/boost/wave/cpplexer/re2clex/cpp_re2c_lexer.hpp
@@ -315,12 +315,13 @@ lexer<IteratorT, PositionT, TokenT>::report_error(Scanner<IteratorT> const *s, i
     BOOST_ASSERT(0 != s);
     BOOST_ASSERT(0 != msg);
 
-    using namespace std;    // some system have vsprintf in namespace std
+    using namespace std;    // some systems have vsnprintf in namespace std
 
-    char buffer[200];           // should be large enough
+    constexpr std::size_t bufsize = 200;            // should be large enough
+    char buffer[bufsize];
     va_list params;
     va_start(params, msg);
-    vsprintf(buffer, msg, params);
+    vsnprintf(buffer, bufsize, msg, params);
     va_end(params);
 
     BOOST_WAVE_LEXER_THROW_VAR(lexing_exception, errcode, buffer, s->line,

--- a/samples/waveidl/idllexer/idl_re2c_lexer.hpp
+++ b/samples/waveidl/idllexer/idl_re2c_lexer.hpp
@@ -165,12 +165,13 @@ lexer<IteratorT, PositionT>::report_error(scanner_t const *s, int errcode,
     BOOST_ASSERT(0 != s);
     BOOST_ASSERT(0 != msg);
 
-    using namespace std;    // some system have vsprintf in namespace std
+    using namespace std;    // some systems have vsnprintf in namespace std
     
-    char buffer[200];           // should be large enough
+    constexpr std::size_t bufsize = 200;           // should be large enough
+    char buffer[bufsize];
     va_list params;
     va_start(params, msg);
-    vsprintf(buffer, msg, params);
+    vsnprintf(buffer, bufsize, msg, params);
     va_end(params);
     
     BOOST_WAVE_LEXER_THROW_VAR(boost::wave::cpplexer::lexing_exception, 


### PR DESCRIPTION
For the usual security reasons. Surfaced by an MSVC warning.