### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,39 @@
+# Copyright René Ferdinand Rivera Morell 2024
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/wave
+    : common-requirements
+        <source>/boost/assert//boost_assert
+        <source>/boost/concept_check//boost_concept_check
+        <source>/boost/config//boost_config
+        <source>/boost/core//boost_core
+        <source>/boost/filesystem//boost_filesystem
+        <source>/boost/format//boost_format
+        <source>/boost/iterator//boost_iterator
+        <source>/boost/lexical_cast//boost_lexical_cast
+        <source>/boost/mpl//boost_mpl
+        <source>/boost/multi_index//boost_multi_index
+        <source>/boost/optional//boost_optional
+        <source>/boost/pool//boost_pool
+        <source>/boost/preprocessor//boost_preprocessor
+        <source>/boost/serialization//boost_serialization
+        <source>/boost/smart_ptr//boost_smart_ptr
+        <source>/boost/spirit//boost_spirit
+        <source>/boost/static_assert//boost_static_assert
+        <source>/boost/throw_exception//boost_throw_exception
+        <source>/boost/type_traits//boost_type_traits
+        <include>include
+    ;
+
+explicit
+    [ alias boost_wave : build//boost_wave ]
+    [ alias all : boost_wave samples test ]
+    ;
+
+call-if : boost-library wave
+    : install boost_wave
+    ;

--- a/build.jam
+++ b/build.jam
@@ -7,25 +7,25 @@ import project ;
 
 project /boost/wave
     : common-requirements
-        <source>/boost/assert//boost_assert
-        <source>/boost/concept_check//boost_concept_check
-        <source>/boost/config//boost_config
-        <source>/boost/core//boost_core
-        <source>/boost/filesystem//boost_filesystem
-        <source>/boost/format//boost_format
-        <source>/boost/iterator//boost_iterator
-        <source>/boost/lexical_cast//boost_lexical_cast
-        <source>/boost/mpl//boost_mpl
-        <source>/boost/multi_index//boost_multi_index
-        <source>/boost/optional//boost_optional
-        <source>/boost/pool//boost_pool
-        <source>/boost/preprocessor//boost_preprocessor
-        <source>/boost/serialization//boost_serialization
-        <source>/boost/smart_ptr//boost_smart_ptr
-        <source>/boost/spirit//boost_spirit
-        <source>/boost/static_assert//boost_static_assert
-        <source>/boost/throw_exception//boost_throw_exception
-        <source>/boost/type_traits//boost_type_traits
+        <library>/boost/assert//boost_assert
+        <library>/boost/concept_check//boost_concept_check
+        <library>/boost/config//boost_config
+        <library>/boost/core//boost_core
+        <library>/boost/filesystem//boost_filesystem
+        <library>/boost/format//boost_format
+        <library>/boost/iterator//boost_iterator
+        <library>/boost/lexical_cast//boost_lexical_cast
+        <library>/boost/mpl//boost_mpl
+        <library>/boost/multi_index//boost_multi_index
+        <library>/boost/optional//boost_optional
+        <library>/boost/pool//boost_pool
+        <library>/boost/preprocessor//boost_preprocessor
+        <library>/boost/serialization//boost_serialization
+        <library>/boost/smart_ptr//boost_smart_ptr
+        <library>/boost/spirit//boost_spirit
+        <library>/boost/static_assert//boost_static_assert
+        <library>/boost/throw_exception//boost_throw_exception
+        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/wave

--- a/build.jam
+++ b/build.jam
@@ -31,7 +31,8 @@ project /boost/wave
 
 explicit
     [ alias boost_wave : build//boost_wave ]
-    [ alias all : boost_wave samples test ]
+    [ alias wave : tool/build//wave ]
+    [ alias all : boost_wave wave samples test ]
     ;
 
 call-if : boost-library wave

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/wave
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -5,27 +5,29 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/assert//boost_assert
+    /boost/concept_check//boost_concept_check
+    /boost/config//boost_config
+    /boost/core//boost_core
+    /boost/filesystem//boost_filesystem
+    /boost/format//boost_format
+    /boost/iterator//boost_iterator
+    /boost/lexical_cast//boost_lexical_cast
+    /boost/mpl//boost_mpl
+    /boost/multi_index//boost_multi_index
+    /boost/optional//boost_optional
+    /boost/pool//boost_pool
+    /boost/preprocessor//boost_preprocessor
+    /boost/serialization//boost_serialization
+    /boost/smart_ptr//boost_smart_ptr
+    /boost/spirit//boost_spirit
+    /boost/static_assert//boost_static_assert
+    /boost/throw_exception//boost_throw_exception
+    /boost/type_traits//boost_type_traits ;
+
 project /boost/wave
     : common-requirements
-        <library>/boost/assert//boost_assert
-        <library>/boost/concept_check//boost_concept_check
-        <library>/boost/config//boost_config
-        <library>/boost/core//boost_core
-        <library>/boost/filesystem//boost_filesystem
-        <library>/boost/format//boost_format
-        <library>/boost/iterator//boost_iterator
-        <library>/boost/lexical_cast//boost_lexical_cast
-        <library>/boost/mpl//boost_mpl
-        <library>/boost/multi_index//boost_multi_index
-        <library>/boost/optional//boost_optional
-        <library>/boost/pool//boost_pool
-        <library>/boost/preprocessor//boost_preprocessor
-        <library>/boost/serialization//boost_serialization
-        <library>/boost/smart_ptr//boost_smart_ptr
-        <library>/boost/spirit//boost_spirit
-        <library>/boost/static_assert//boost_static_assert
-        <library>/boost/throw_exception//boost_throw_exception
-        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 
@@ -38,3 +40,4 @@ explicit
 call-if : boost-library wave
     : install boost_wave
     ;
+

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -8,9 +8,11 @@
 # Software License, Version 1.0. (See accompanying file 
 # LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-import ../../config/checks/config : requires ;
+require-b2 5.0.1 ;
+import-search /boost/config/checks ;
+import config : requires ;
 
-project boost/wave
+project
     : requirements
       [ requires
         cxx11_constexpr
@@ -45,8 +47,8 @@ SOURCES =
 lib boost_wave
     :
     $(SOURCES)
-    ../../filesystem/build//boost_filesystem
-    ../../thread/build//boost_thread
+    /boost/filesystem//boost_filesystem
+    /boost/thread//boost_thread
     ;
 
 for local source in $(SOURCES)
@@ -69,5 +71,3 @@ for local source in $(SOURCES)
 
     obj $(source) : $(source).cpp : $(requirements) ;
 }
-
-boost-install boost_wave ;

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -13,6 +13,7 @@ import-search /boost/config/checks ;
 import config : requires ;
 
 project
+    : common-requirements <library>$(boost_dependencies)
     : requirements
       [ requires
         cxx11_constexpr

--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -4,8 +4,8 @@
 #
 # http://www.boost.org/
 #
-# Copyright (c) 2001-2011 Hartmut Kaiser. Distributed under the Boost 
-# Software License, Version 1.0. (See accompanying file 
+# Copyright (c) 2001-2011 Hartmut Kaiser. Distributed under the Boost
+# Software License, Version 1.0. (See accompanying file
 # LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 require-b2 5.0.1 ;
@@ -27,6 +27,8 @@ project
       <toolset>msvc:<define>_SCL_SECURE_NO_DEPRECATE
       <toolset>msvc:<define>_CRT_SECURE_NO_DEPRECATE
     : source-location ../src
+    : usage-requirements
+        <define>BOOST_ALL_NO_LIB=1
     ;
 
 SOURCES =

--- a/samples/Jamfile.v2
+++ b/samples/Jamfile.v2
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt
 # or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.0.1 ;
+import-search /boost/config/checks ;
 import config : requires ;
 
 project 

--- a/samples/check_macro_naming/check_macro_naming.cpp
+++ b/samples/check_macro_naming/check_macro_naming.cpp
@@ -11,7 +11,7 @@
 =============================================================================*/
 
 #include "check_macro_naming.hpp"
-#include "libs/filesystem/include/boost/filesystem/file_status.hpp"
+#include "boost/filesystem/file_status.hpp"
 
 ///////////////////////////////////////////////////////////////////////////////
 //  Utilities from the rest of Boost

--- a/samples/cpp_tokens/build/Jamfile.v2
+++ b/samples/cpp_tokens/build/Jamfile.v2
@@ -4,27 +4,28 @@
 #
 # http://www.boost.org/
 #
-# Copyright (c) 2001-2010 Hartmut Kaiser. Distributed under the Boost 
-# Software License, Version 1.0. (See accompanying file 
+# Copyright (c) 2001-2010 Hartmut Kaiser. Distributed under the Boost
+# Software License, Version 1.0. (See accompanying file
 # LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+project : requirements <library>/boost/wave//boost_wave ;
+
 SOURCES =
-        ../cpp_tokens 
-        ../instantiate_cpp_exprgrammar 
-        ../instantiate_cpp_grammar 
+        ../cpp_tokens
+        ../instantiate_cpp_exprgrammar
+        ../instantiate_cpp_grammar
         ../instantiate_cpp_literalgrs
         ../instantiate_defined_grammar
         ../instantiate_has_include_grammar
-        ../instantiate_slex_lexer 
+        ../instantiate_slex_lexer
     ;
 
 exe cpp_tokens
     :
         $(SOURCES)
-        /boost/wave//boost_wave
         /boost/program_options//boost_program_options
-        /boost/filesystem//boost_filesystem     
-        /boost/system//boost_system     
+        /boost/filesystem//boost_filesystem
+        /boost/system//boost_system
         /boost/thread//boost_thread
     ;
 

--- a/samples/list_includes/build/Jamfile.v2
+++ b/samples/list_includes/build/Jamfile.v2
@@ -18,14 +18,18 @@ SOURCES =
         ../instantiate_lexertl_lexer 
     ;
 
+project
+    : requirements
+        <source>/boost/wave//boost_wave
+        <source>/boost/program_options//boost_program_options/<link>static
+        <source>/boost/filesystem//boost_filesystem
+        <source>/boost/system//boost_system
+        <source>/boost/thread//boost_thread
+    ;
+
 exe list_includes
     :
         $(SOURCES)
-        /boost/wave//boost_wave
-        /boost/program_options//boost_program_options/<link>static
-        /boost/filesystem//boost_filesystem     
-        /boost/system//boost_system     
-        /boost/thread//boost_thread
     ;
 
 for local source in $(SOURCES)

--- a/samples/list_includes/build/Jamfile.v2
+++ b/samples/list_includes/build/Jamfile.v2
@@ -4,27 +4,27 @@
 #
 # http://www.boost.org/
 #
-# Copyright (c) 2001-2010 Hartmut Kaiser. Distributed under the Boost 
-# Software License, Version 1.0. (See accompanying file 
+# Copyright (c) 2001-2010 Hartmut Kaiser. Distributed under the Boost
+# Software License, Version 1.0. (See accompanying file
 # LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 SOURCES =
         ../list_includes
-        ../instantiate_cpp_exprgrammar 
-        ../instantiate_cpp_grammar 
+        ../instantiate_cpp_exprgrammar
+        ../instantiate_cpp_grammar
         ../instantiate_cpp_literalgrs
         ../instantiate_defined_grammar
         ../instantiate_has_include_grammar
-        ../instantiate_lexertl_lexer 
+        ../instantiate_lexertl_lexer
     ;
 
 project
     : requirements
-        <source>/boost/wave//boost_wave
-        <source>/boost/program_options//boost_program_options/<link>static
-        <source>/boost/filesystem//boost_filesystem
-        <source>/boost/system//boost_system
-        <source>/boost/thread//boost_thread
+        <library>/boost/wave//boost_wave
+        <library>/boost/program_options//boost_program_options/<link>static
+        <library>/boost/filesystem//boost_filesystem
+        <library>/boost/system//boost_system
+        <library>/boost/thread//boost_thread
     ;
 
 exe list_includes
@@ -36,7 +36,7 @@ for local source in $(SOURCES)
 {
     local requirements ;
     # workaround for compiler bug
-    requirements += <toolset-msvc:version>7.1:<rtti>off ; 
-    requirements += <toolset-msvc:version>7.1_stlport4:<rtti>off ; 
+    requirements += <toolset-msvc:version>7.1:<rtti>off ;
+    requirements += <toolset-msvc:version>7.1_stlport4:<rtti>off ;
     obj $(source) : $(source).cpp : $(requirements) ;
 }

--- a/samples/token_statistics/build/Jamfile.v2
+++ b/samples/token_statistics/build/Jamfile.v2
@@ -16,14 +16,19 @@ SOURCES =
         ../instantiate_has_include_grammar
     ;
 
+project
+    : requirements
+        <source>/boost/wave//boost_wave
+        <source>/boost/program_options//boost_program_options/<link>static
+        <source>/boost/filesystem//boost_filesystem
+        <source>/boost/system//boost_system
+        <source>/boost/thread//boost_thread
+        <source>/boost/xpressive//boost_xpressive
+    ;
+
 exe token_statistics
     :
         $(SOURCES)
-        /boost/wave//boost_wave
-        /boost/program_options//boost_program_options/<link>static
-        /boost/filesystem//boost_filesystem     
-        /boost/system//boost_system     
-        /boost/thread//boost_thread
     ;
 
 for local source in $(SOURCES)

--- a/samples/token_statistics/build/Jamfile.v2
+++ b/samples/token_statistics/build/Jamfile.v2
@@ -4,12 +4,12 @@
 #
 # http://www.boost.org/
 #
-# Copyright (c) 2001-2010 Hartmut Kaiser. Distributed under the Boost 
-# Software License, Version 1.0. (See accompanying file 
+# Copyright (c) 2001-2010 Hartmut Kaiser. Distributed under the Boost
+# Software License, Version 1.0. (See accompanying file
 # LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-SOURCES = 
-        ../token_statistics 
+SOURCES =
+        ../token_statistics
         ../instantiate_xlex_lexer
         ../instantiate_cpp_grammar
         ../instantiate_defined_grammar
@@ -18,12 +18,12 @@ SOURCES =
 
 project
     : requirements
-        <source>/boost/wave//boost_wave
-        <source>/boost/program_options//boost_program_options/<link>static
-        <source>/boost/filesystem//boost_filesystem
-        <source>/boost/system//boost_system
-        <source>/boost/thread//boost_thread
-        <source>/boost/xpressive//boost_xpressive
+        <library>/boost/wave//boost_wave
+        <library>/boost/program_options//boost_program_options/<link>static
+        <library>/boost/filesystem//boost_filesystem
+        <library>/boost/system//boost_system
+        <library>/boost/thread//boost_thread
+        <library>/boost/xpressive//boost_xpressive
     ;
 
 exe token_statistics

--- a/samples/waveidl/build/Jamfile.v2
+++ b/samples/waveidl/build/Jamfile.v2
@@ -4,11 +4,11 @@
 #
 # http://www.boost.org/
 #
-# Copyright (c) 2001-2010 Hartmut Kaiser. Distributed under the Boost 
-# Software License, Version 1.0. (See accompanying file 
+# Copyright (c) 2001-2010 Hartmut Kaiser. Distributed under the Boost
+# Software License, Version 1.0. (See accompanying file
 # LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-SOURCES = 
+SOURCES =
         ../idl
         ../instantiate_cpp_grammar
         ../instantiate_defined_grammar
@@ -21,11 +21,11 @@ SOURCES =
 
 project
     : requirements
-        <source>/boost/wave//boost_wave
-        <source>/boost/program_options//boost_program_options/<link>static
-        <source>/boost/system//boost_system
-        <source>/boost/thread//boost_thread
-        <source>/boost/filesystem//boost_filesystem
+        <library>/boost/wave//boost_wave
+        <library>/boost/program_options//boost_program_options/<link>static
+        <library>/boost/system//boost_system
+        <library>/boost/thread//boost_thread
+        <library>/boost/filesystem//boost_filesystem
     ;
 
 exe waveidl

--- a/samples/waveidl/build/Jamfile.v2
+++ b/samples/waveidl/build/Jamfile.v2
@@ -17,16 +17,20 @@ SOURCES =
         ../instantiate_re2c_lexer
         ../instantiate_re2c_lexer_str
         ../idllexer/idl_re
-	;
-	
+    ;
+
+project
+    : requirements
+        <source>/boost/wave//boost_wave
+        <source>/boost/program_options//boost_program_options/<link>static
+        <source>/boost/system//boost_system
+        <source>/boost/thread//boost_thread
+        <source>/boost/filesystem//boost_filesystem
+    ;
+
 exe waveidl
     :
         $(SOURCES)
-        /boost/wave//boost_wave
-        /boost/program_options//boost_program_options/<link>static
-        /boost/system//boost_system
-        /boost/thread//boost_thread
-        /boost/filesystem//boost_filesystem
     ;
 
 for local source in $(SOURCES)

--- a/test/build/Jamfile.v2
+++ b/test/build/Jamfile.v2
@@ -8,7 +8,11 @@
 # Software License, Version 1.0. (See accompanying file 
 # LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.0.1 ;
+import-search /boost/config/checks ;
 import config : requires ;
+import project ;
+import path ;
 
 #
 # These are the sources to compile for the testwave application
@@ -22,8 +26,22 @@ SOURCES_DYNAMIC = testwave_dll testwave_app_dll
 SOURCES = $(SOURCE_STATIC) $(SOURCES_DYNAMIC)
     ;
     
-path-constant TESTWAVE_DIR : $(BOOST_ROOT)/libs/wave/test/testwave/testfiles 
+path-constant TESTWAVE_DIR : ../testwave/testfiles 
     ;
+
+path-constant WAVE_INCLUDE_DIR : ../../include
+    ;
+
+path-constant SAMPLES_DIR : ../../samples
+    ;
+
+#
+# We need the Boost Config project for the boost/version.hpp header file.
+#
+local boost-config-attributes
+    = [ project.attributes [ project.is-registered-id /boost/config ] ] ;
+local BOOST_CONFIG_INCLUDE_DIR
+    = [ path.join [ $(boost-config-attributes).get location ] include ] ;
 
 #
 # This are the arguments for the testwave executable
@@ -32,7 +50,8 @@ TESTWAVE_ARGUMENTS =
         -d4                              # use -d4 for verbose results 
         --hooks=1                        # test hooks as well
         -S$(TESTWAVE_DIR) 
-        -S$(BOOST_ROOT) -I$(BOOST_ROOT)
+        -S$(WAVE_INCLUDE_DIR) -I$(WAVE_INCLUDE_DIR)
+        -S$(BOOST_CONFIG_INCLUDE_DIR) -I$(BOOST_CONFIG_INCLUDE_DIR)
     ;
 
 #
@@ -41,7 +60,7 @@ TESTWAVE_ARGUMENTS =
 TESTWAVE_FILES = test.cfg
     ;
 
-project wave/test
+project
     : requirements
       [ requires
         cxx11_constexpr
@@ -51,6 +70,7 @@ project wave/test
         cxx11_hdr_mutex
         cxx11_hdr_regex
       ]
+      <include>$(SAMPLES_DIR)
     ;
 
 for local source in $(SOURCES)
@@ -58,6 +78,10 @@ for local source in $(SOURCES)
     local requirements ;
     requirements += <toolset-msvc:version>7.1:<rtti>off ; # workaround for compiler bug
     requirements += <toolset-msvc:version>7.1_stlport4:<rtti>off ; 
+    requirements +=
+        <source>/boost/any//boost_any
+        <source>/boost/program_options//boost_program_options
+        ;
     obj $(source) : ../testwave/$(source).cpp : $(requirements) ;
 }
 
@@ -133,6 +157,7 @@ test-suite wave
                 /boost/filesystem//boost_filesystem
                 /boost/thread//boost_thread
                 /boost/system//boost_system
+                /boost/xpressive//boost_xpressive
             :
             # arguments
             :
@@ -211,6 +236,7 @@ test-suite wave
                 /boost/filesystem//boost_filesystem
                 /boost/thread//boost_thread
                 /boost/system//boost_system
+                /boost/xpressive//boost_xpressive
             :
             # arguments
             :

--- a/test/testlexers/test_lexertl_lexer.cpp
+++ b/test/testlexers/test_lexertl_lexer.cpp
@@ -24,7 +24,7 @@
 
 //  include the lexertl lexer related stuff
 #include <boost/wave/cpplexer/cpp_lex_token.hpp>                      // token type
-#include <libs/wave/samples/list_includes/lexertl/lexertl_lexer.hpp>  // lexer type
+#include <list_includes/lexertl/lexertl_lexer.hpp>  // lexer type
 
 typedef boost::wave::cpplexer::lex_token<> token_type;
 typedef boost::wave::cpplexer::lexertl::lex_iterator<token_type> lexer_type;

--- a/test/testlexers/test_slex_lexer.cpp
+++ b/test/testlexers/test_slex_lexer.cpp
@@ -27,8 +27,8 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 //  include the Slex lexer related stuff
-#include <libs/wave/samples/cpp_tokens/slex_token.hpp>            // token type
-#include <libs/wave/samples/cpp_tokens/slex/cpp_slex_lexer.hpp>   // lexer type
+#include <cpp_tokens/slex_token.hpp>            // token type
+#include <cpp_tokens/slex/cpp_slex_lexer.hpp>   // lexer type
 
 typedef boost::wave::cpplexer::slex_token<> token_type;
 typedef boost::wave::cpplexer::slex::slex_iterator<token_type> lexer_type;

--- a/test/testlexers/test_xlex_lexer.cpp
+++ b/test/testlexers/test_xlex_lexer.cpp
@@ -26,8 +26,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 //  include the Xpressive lexer related stuff
 #include <boost/wave/cpplexer/cpp_lex_token.hpp>                  // token type
-#include <libs/wave/samples/token_statistics/xlex/xlex_lexer.hpp> // lexer type
-#include <libs/wave/samples/token_statistics/xlex_iterator.hpp>   // iterator
+#include <token_statistics/xlex/xlex_lexer.hpp> // lexer type
+#include <token_statistics/xlex_iterator.hpp>   // iterator
 
 typedef boost::wave::cpplexer::lex_token<> token_type;
 typedef boost::wave::cpplexer::xlex::xlex_iterator<token_type> lexer_type;

--- a/tool/build/Jamfile.v2
+++ b/tool/build/Jamfile.v2
@@ -34,13 +34,14 @@ project
 exe wave
     :
     ../cpp.cpp 
-    /boost//wave
-    /boost//program_options
-    /boost//filesystem
-    /boost//serialization
-    /boost//system
-    /boost//thread
+    /boost/wave//boost_wave
+    /boost/program_options//boost_program_options
+    /boost/filesystem//boost_filesystem
+    /boost/serialization//boost_serialization
+    /boost/system//boost_system
+    /boost/thread//boost_thread
     /boost/timer//boost_timer/<link>static
+    /boost/foreach//boost_foreach
     :
     <threading>multi
 #   <debug-symbols>on
@@ -49,8 +50,8 @@ exe wave
     release
     ;
     
-local bindir = [ option.get bindir : ../../../dist/bin ] ;
-local libdir = [ option.get libdir : ../../../dist/lib ] ;
+local bindir = [ option.get bindir : ../dist/bin ] ;
+local libdir = [ option.get libdir : ../dist/lib ] ;
 
 install dist-bin
     :


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.