### PR TITLE
Use only node16 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: GitHub Actions CI
 
+# permit node16 use as a workaround for node20's differing glibc version
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 on:
   pull_request:
   push:
@@ -107,7 +111,7 @@ jobs:
             sudo python3 get-pip.py
             sudo /usr/local/bin/pip install cmake
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: linux
         shell: bash
@@ -205,7 +209,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set DEVELOPER_DIR
         if: matrix.xcode_version != ''


### PR DESCRIPTION
To test against different compiler versions we use older Docker images, which in turn have different glibc versions. Github recently deprecated Node version 16, which had been built with an older glibc version, and the newer Node version requires a glibc version that is not available on the old images, causing builds to fail.

This is a hack permitting the continued use of Node 16, until Github decides to make it impossible.