### PR TITLE
Add support for GNU's named variadics for macros.

### DIFF
--- a/include/boost/wave/cpp_exceptions.hpp
+++ b/include/boost/wave/cpp_exceptions.hpp
@@ -267,8 +267,7 @@ public:
             "ill formed #define directive",             // bad_define_statement
             "__VA_ARGS__ can only appear in the "
             "expansion of a C99 variadic macro",        // bad_define_statement_va_args
-            "named variadic like x... is disabled, "
-            "please enable_named_variadics() to enable",  // bad_define_statement_named_va_args
+            "named variadic like x... is disabled",     // bad_define_statement_named_va_args
             "__VA_OPT__ can only appear in the "
             "expansion of a C++20 variadic macro",      // bad_define_statement_va_opt
             "__VA_OPT__ must be followed by a left "

--- a/include/boost/wave/cpp_exceptions.hpp
+++ b/include/boost/wave/cpp_exceptions.hpp
@@ -116,6 +116,7 @@ public:
         ill_formed_operator,
         bad_define_statement,
         bad_define_statement_va_args,
+        bad_define_statement_named_va_args,
         bad_define_statement_va_opt,
         bad_define_statement_va_opt_parens,
         bad_define_statement_va_opt_recurse,
@@ -209,6 +210,7 @@ public:
         case preprocess_exception::unbalanced_if_endif:
         case preprocess_exception::bad_define_statement:
         case preprocess_exception::bad_define_statement_va_args:
+        case preprocess_exception::bad_define_statement_named_va_args:
         case preprocess_exception::bad_define_statement_va_opt:
         case preprocess_exception::bad_define_statement_va_opt_parens:
         case preprocess_exception::bad_define_statement_va_opt_recurse:
@@ -265,6 +267,8 @@ public:
             "ill formed #define directive",             // bad_define_statement
             "__VA_ARGS__ can only appear in the "
             "expansion of a C99 variadic macro",        // bad_define_statement_va_args
+            "named variadic like x... is disabled, "
+            "please enable_named_variadics() to enable",  // bad_define_statement_named_va_args
             "__VA_OPT__ can only appear in the "
             "expansion of a C++20 variadic macro",      // bad_define_statement_va_opt
             "__VA_OPT__ must be followed by a left "
@@ -334,6 +338,7 @@ public:
             util::severity_error,              // ill_formed_operator
             util::severity_error,              // bad_define_statement
             util::severity_error,              // bad_define_statement_va_args
+            util::severity_error,              // bad_define_statement_named_va_args
             util::severity_error,              // bad_define_statement_va_opt
             util::severity_error,              // bad_define_statement_va_opt_parens
             util::severity_error,              // bad_define_statement_va_opt_recurse

--- a/include/boost/wave/grammars/cpp_grammar.hpp
+++ b/include/boost/wave/grammars/cpp_grammar.hpp
@@ -355,6 +355,7 @@ struct cpp_grammar :
             const auto &named_variadics = [](tree_node<node_t>& node, iterator_t begin, iterator_t end) {
                 container_iterator_t it = node.value.begin();
                 it->set_token_id(T_GNU_NAMED_ELLIPSIS);
+                it->set_value(it->get_value() + "...");
             };
 #endif
 #endif

--- a/include/boost/wave/grammars/cpp_grammar.hpp
+++ b/include/boost/wave/grammars/cpp_grammar.hpp
@@ -363,6 +363,7 @@ struct cpp_grammar :
 #if BOOST_WAVE_SUPPORT_VARIADICS_PLACEMARKERS != 0
 #if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS != 0
                             |   lexeme_d[ch_p(T_IDENTIFIER) >> ch_p(T_ELLIPSIS)]
+                            |   ch_p(T_IDENTIFIER) >> ch_p(T_ELLIPSIS)
 #endif
                             |   ch_p(T_ELLIPSIS)
 #endif

--- a/include/boost/wave/grammars/cpp_grammar.hpp
+++ b/include/boost/wave/grammars/cpp_grammar.hpp
@@ -354,16 +354,19 @@ struct cpp_grammar :
                 =   confix_p(
                         no_node_d[ch_p(T_LEFTPAREN) >> *ppsp],
                        !list_p(
-                            (   ch_p(T_IDENTIFIER)
-                            |   pattern_p(KeywordTokenType,
+                            (   pattern_p(KeywordTokenType,
                                     TokenTypeMask|PPTokenFlag)
                             |   pattern_p(OperatorTokenType|AltExtTokenType,
                                     ExtTokenTypeMask|PPTokenFlag)   // and, bit_and etc.
                             |   pattern_p(BoolLiteralTokenType,
                                     TokenTypeMask|PPTokenFlag)  // true/false
 #if BOOST_WAVE_SUPPORT_VARIADICS_PLACEMARKERS != 0
+#if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS != 0
+                            |   lexeme_d[ch_p(T_IDENTIFIER) >> ch_p(T_ELLIPSIS)]
+#endif
                             |   ch_p(T_ELLIPSIS)
 #endif
+                            |   ch_p(T_IDENTIFIER) // must be after the named variadic
                             ),
                             no_node_d[*ppsp >> ch_p(T_COMMA) >> *ppsp]
                         ),

--- a/include/boost/wave/grammars/cpp_grammar.hpp
+++ b/include/boost/wave/grammars/cpp_grammar.hpp
@@ -347,7 +347,17 @@ struct cpp_grammar :
                             )
                         )
                 ;
-
+#if BOOST_WAVE_SUPPORT_VARIADICS_PLACEMARKERS != 0
+#if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS != 0
+            typedef typename ScannerT::iterator_t iterator_t;
+            typedef node_val_data<iterator_t, nil_t> node_t;
+            typedef typename node_t::iterator_t container_iterator_t;
+            const auto &named_variadics = [](tree_node<node_t>& node, iterator_t begin, iterator_t end) {
+                container_iterator_t it = node.value.begin();
+                it->set_token_id(T_GNU_NAMED_ELLIPSIS);
+            };
+#endif
+#endif
         // parameter list
         // normal C++ mode
             macro_parameters
@@ -362,8 +372,12 @@ struct cpp_grammar :
                                     TokenTypeMask|PPTokenFlag)  // true/false
 #if BOOST_WAVE_SUPPORT_VARIADICS_PLACEMARKERS != 0
 #if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS != 0
-                            |   lexeme_d[ch_p(T_IDENTIFIER) >> ch_p(T_ELLIPSIS)]
-                            |   ch_p(T_IDENTIFIER) >> ch_p(T_ELLIPSIS)
+                            |   access_node_d[
+                                    token_node_d[
+                                        lexeme_d[ch_p(T_IDENTIFIER) >> ch_p(T_ELLIPSIS)]
+                                    |   (ch_p(T_IDENTIFIER) >> ch_p(T_ELLIPSIS))
+                                ]][named_variadics]
+
 #endif
                             |   ch_p(T_ELLIPSIS)
 #endif

--- a/include/boost/wave/grammars/cpp_grammar.hpp
+++ b/include/boost/wave/grammars/cpp_grammar.hpp
@@ -373,12 +373,8 @@ struct cpp_grammar :
                                     TokenTypeMask|PPTokenFlag)  // true/false
 #if BOOST_WAVE_SUPPORT_VARIADICS_PLACEMARKERS != 0
 #if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS != 0
-                            |   access_node_d[
-                                    token_node_d[
-                                        lexeme_d[ch_p(T_IDENTIFIER) >> ch_p(T_ELLIPSIS)]
-                                    |   (ch_p(T_IDENTIFIER) >> ch_p(T_ELLIPSIS))
-                                ]][named_variadics]
-
+                            |   access_node_d[token_node_d[(ch_p(T_IDENTIFIER) >> *ppsp >> ch_p(T_ELLIPSIS))]]
+                                [named_variadics]
 #endif
                             |   ch_p(T_ELLIPSIS)
 #endif

--- a/include/boost/wave/language_support.hpp
+++ b/include/boost/wave/language_support.hpp
@@ -33,6 +33,9 @@ enum language_support {
     //  support flags for C99
     support_option_variadics = 0x04,
     support_c99 = support_option_variadics | support_option_long_long | 0x08,
+#if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS != 0
+    support_option_named_variadics = 0x100000,
+#endif
 #endif
 #if BOOST_WAVE_SUPPORT_CPP0X != 0
     //  support flags for C++11
@@ -61,7 +64,7 @@ enum language_support {
 #endif
 #endif
 
-    support_option_mask = 0x1FFC0,
+    support_option_mask = 0xFFC0,
     support_option_emit_contnewlines = 0x0040,
     support_option_insert_whitespace = 0x0080,
     support_option_preserve_comments = 0x0100,
@@ -72,7 +75,6 @@ enum language_support {
     support_option_emit_line_directives = 0x2000,
     support_option_include_guard_detection = 0x4000,
     support_option_emit_pragma_directives = 0x8000,
-    support_option_named_variadics = 0x10000,
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -241,7 +243,9 @@ BOOST_WAVE_OPTION(include_guard_detection)   // support_option_include_guard_det
 #endif
 #if BOOST_WAVE_SUPPORT_VARIADICS_PLACEMARKERS != 0
 BOOST_WAVE_OPTION(variadics)                 // support_option_variadics
-BOOST_WAVE_OPTION(named_variadics)           // support_option_named_variadic
+#if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS != 0
+BOOST_WAVE_OPTION(named_variadics)           // support_option_named_variadics
+#endif
 #endif
 #if BOOST_WAVE_SUPPORT_VA_OPT != 0
 BOOST_WAVE_OPTION(va_opt)                    // support_option_va_opt

--- a/include/boost/wave/language_support.hpp
+++ b/include/boost/wave/language_support.hpp
@@ -34,7 +34,7 @@ enum language_support {
     support_option_variadics = 0x04,
     support_c99 = support_option_variadics | support_option_long_long | 0x08,
 #if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS != 0
-    support_option_named_variadics = 0x100000,
+    support_option_gnu_named_variadics = 0x100000,
 #endif
 #endif
 #if BOOST_WAVE_SUPPORT_CPP0X != 0
@@ -244,7 +244,7 @@ BOOST_WAVE_OPTION(include_guard_detection)   // support_option_include_guard_det
 #if BOOST_WAVE_SUPPORT_VARIADICS_PLACEMARKERS != 0
 BOOST_WAVE_OPTION(variadics)                 // support_option_variadics
 #if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS != 0
-BOOST_WAVE_OPTION(named_variadics)           // support_option_named_variadics
+BOOST_WAVE_OPTION(gnu_named_variadics)           // support_option_named_variadics
 #endif
 #endif
 #if BOOST_WAVE_SUPPORT_VA_OPT != 0

--- a/include/boost/wave/language_support.hpp
+++ b/include/boost/wave/language_support.hpp
@@ -64,7 +64,7 @@ enum language_support {
 #endif
 #endif
 
-    support_option_mask = 0xFFC0,
+    support_option_mask = 0x10FFC0,
     support_option_emit_contnewlines = 0x0040,
     support_option_insert_whitespace = 0x0080,
     support_option_preserve_comments = 0x0100,

--- a/include/boost/wave/language_support.hpp
+++ b/include/boost/wave/language_support.hpp
@@ -61,7 +61,7 @@ enum language_support {
 #endif
 #endif
 
-    support_option_mask = 0xFFC0,
+    support_option_mask = 0x1FFC0,
     support_option_emit_contnewlines = 0x0040,
     support_option_insert_whitespace = 0x0080,
     support_option_preserve_comments = 0x0100,
@@ -71,7 +71,8 @@ enum language_support {
     support_option_prefer_pp_numbers = 0x1000,
     support_option_emit_line_directives = 0x2000,
     support_option_include_guard_detection = 0x4000,
-    support_option_emit_pragma_directives = 0x8000
+    support_option_emit_pragma_directives = 0x8000,
+    support_option_named_variadics = 0x10000,
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -240,6 +241,7 @@ BOOST_WAVE_OPTION(include_guard_detection)   // support_option_include_guard_det
 #endif
 #if BOOST_WAVE_SUPPORT_VARIADICS_PLACEMARKERS != 0
 BOOST_WAVE_OPTION(variadics)                 // support_option_variadics
+BOOST_WAVE_OPTION(named_variadics)           // support_option_named_variadic
 #endif
 #if BOOST_WAVE_SUPPORT_VA_OPT != 0
 BOOST_WAVE_OPTION(va_opt)                    // support_option_va_opt

--- a/include/boost/wave/token_ids.hpp
+++ b/include/boost/wave/token_ids.hpp
@@ -315,6 +315,9 @@ enum token_id : std::uint32_t {
 // C++20 operators
     T_SPACESHIP    = TOKEN_FROM_ID(441, OperatorTokenType),
 
+// GNU named variadics
+    T_GNU_NAMED_ELLIPSIS = TOKEN_FROM_ID(442, IdentifierTokenType),
+
     T_LAST_TOKEN_ID,
     T_LAST_TOKEN = ID_FROM_TOKEN(T_LAST_TOKEN_ID & ~PPTokenFlag),
 

--- a/include/boost/wave/util/cpp_iterator.hpp
+++ b/include/boost/wave/util/cpp_iterator.hpp
@@ -1742,17 +1742,16 @@ pp_iterator_functor<ContextT>::on_define (parse_node_type const &node)
                 }
 #if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS != 0
                 if (T_GNU_NAMED_ELLIPSIS == token_id(*pit)) {
-                  if (boost::wave::need_named_variadics(ctx.get_language()))
-                    seen_ellipses = true;
-                  else {
-                    // named variadics are not supported
-                    BOOST_WAVE_THROW_CTX(ctx, preprocess_exception,
-                        bad_define_statement_named_va_args, macroname.get_value().c_str(),
-                        (*pit).get_position());
-                    return;
-                  }
+                    if (boost::wave::need_named_variadics(ctx.get_language())) {
+                        seen_ellipses = true;
+                    } else {
+                        // named variadics are not supported
+                        BOOST_WAVE_THROW_CTX(ctx, preprocess_exception,
+                            bad_define_statement_named_va_args, macroname.get_value().c_str(),
+                            (*pit).get_position());
+                        return;
+                    }
                 }
-
                 if (named_variadic == (*pit).get_value()) {
                     // can't use named_variadic as a argument name
                     BOOST_WAVE_THROW_CTX(ctx, preprocess_exception,

--- a/include/boost/wave/util/cpp_iterator.hpp
+++ b/include/boost/wave/util/cpp_iterator.hpp
@@ -1721,7 +1721,7 @@ pp_iterator_functor<ContextT>::on_define (parse_node_type const &node)
 
 #if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS != 0
             string_type named_variadic;
-            if (boost::wave::need_named_variadics(ctx.get_language()) &&
+            if (boost::wave::need_gnu_named_variadics(ctx.get_language()) &&
                 token_id(macroparameters.back()) == T_GNU_NAMED_ELLIPSIS) {
                 named_variadic = macroparameters.back().get_value();
                 named_variadic = named_variadic.substr(0, named_variadic.size()-3);
@@ -1742,7 +1742,7 @@ pp_iterator_functor<ContextT>::on_define (parse_node_type const &node)
                 }
 #if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS != 0
                 if (T_GNU_NAMED_ELLIPSIS == token_id(*pit)) {
-                    if (boost::wave::need_named_variadics(ctx.get_language())) {
+                    if (boost::wave::need_gnu_named_variadics(ctx.get_language())) {
                         seen_ellipses = true;
                     } else {
                         // named variadics are not supported

--- a/include/boost/wave/util/cpp_iterator.hpp
+++ b/include/boost/wave/util/cpp_iterator.hpp
@@ -1719,6 +1719,15 @@ pp_iterator_functor<ContextT>::on_define (parse_node_type const &node)
             typedef typename std::vector<result_type>::iterator
                 parameter_iterator_t;
 
+#if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS != 0
+            string_type named_variadic;
+            if (boost::wave::need_named_variadics(ctx.get_language()) &&
+                token_id(macroparameters.back()) == T_GNU_NAMED_ELLIPSIS) {
+                named_variadic = macroparameters.back().get_value();
+                named_variadic = named_variadic.substr(0, named_variadic.size()-3);
+            }
+#endif
+
             bool seen_ellipses = false;
             parameter_iterator_t end = macroparameters.end();
             for (parameter_iterator_t pit = macroparameters.begin();
@@ -1742,6 +1751,14 @@ pp_iterator_functor<ContextT>::on_define (parse_node_type const &node)
                         (*pit).get_position());
                     return;
                   }
+                }
+
+                if (named_variadic == (*pit).get_value()) {
+                    // can't use named_variadic as a argument name
+                    BOOST_WAVE_THROW_CTX(ctx, preprocess_exception,
+                        duplicate_parameter_name,
+                        macroname.get_value().c_str(), (*pit).get_position());
+                    return;
                 }
 #endif
                 if (T_ELLIPSIS == token_id(*pit))

--- a/include/boost/wave/util/cpp_iterator.hpp
+++ b/include/boost/wave/util/cpp_iterator.hpp
@@ -1722,6 +1722,7 @@ pp_iterator_functor<ContextT>::on_define (parse_node_type const &node)
 #if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS != 0
             string_type named_variadic;
             if (boost::wave::need_gnu_named_variadics(ctx.get_language()) &&
+                macroparameters.size() > 0 &&
                 token_id(macroparameters.back()) == T_GNU_NAMED_ELLIPSIS) {
                 named_variadic = macroparameters.back().get_value();
                 named_variadic = named_variadic.substr(0, named_variadic.size()-3);

--- a/include/boost/wave/util/cpp_iterator.hpp
+++ b/include/boost/wave/util/cpp_iterator.hpp
@@ -1731,6 +1731,19 @@ pp_iterator_functor<ContextT>::on_define (parse_node_type const &node)
                         (*pit).get_position());
                     return;
                 }
+#if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS != 0
+                if (T_GNU_NAMED_ELLIPSIS == token_id(*pit)) {
+                  if (boost::wave::need_named_variadics(ctx.get_language()))
+                    seen_ellipses = true;
+                  else {
+                    // named variadics are not supported
+                    BOOST_WAVE_THROW_CTX(ctx, preprocess_exception,
+                        bad_define_statement_named_va_args, macroname.get_value().c_str(),
+                        (*pit).get_position());
+                    return;
+                  }
+                }
+#endif
                 if (T_ELLIPSIS == token_id(*pit))
                     seen_ellipses = true;
 

--- a/include/boost/wave/util/cpp_macromap.hpp
+++ b/include/boost/wave/util/cpp_macromap.hpp
@@ -1493,7 +1493,11 @@ macromap<ContextT>::expand_macro(ContainerT &expanded,
                 // entirely, so reduce the mandatory argument count by one
                 // if the last parameter is ellipsis:
                 if ((parm_count_required > 0) &&
-                    (T_ELLIPSIS == token_id(macro_def.macroparameters.back()))) {
+                    (T_ELLIPSIS == token_id(macro_def.macroparameters.back()) 
+#if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS != 0
+                    || T_GNU_NAMED_ELLIPSIS == token_id(macro_def.macroparameters.back())
+#endif
+                     )) {
                     --parm_count_required;
                 }
             }

--- a/include/boost/wave/util/cpp_macromap.hpp
+++ b/include/boost/wave/util/cpp_macromap.hpp
@@ -1486,6 +1486,7 @@ macromap<ContextT>::expand_macro(ContainerT &expanded,
                     macro_def.macroparameters.size(), seen_newline);
 
             std::size_t parm_count_required = macro_def.macroparameters.size();
+#if BOOST_WAVE_SUPPORT_VARIADICS_PLACEMARKERS != 0
 #if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS != 0
             if (boost::wave::need_named_variadics(ctx.get_language())) {
                 if ((parm_count_required >= 2) && 
@@ -1493,6 +1494,7 @@ macromap<ContextT>::expand_macro(ContainerT &expanded,
                     T_IDENTIFIER == token_id(*(macro_def.macroparameters.end() - 2)))
                     --parm_count_required; 
             }
+#endif
 #endif
 #if BOOST_WAVE_SUPPORT_CPP2A
             if (boost::wave::need_cpp2a(ctx.get_language())) {

--- a/include/boost/wave/util/cpp_macromap.hpp
+++ b/include/boost/wave/util/cpp_macromap.hpp
@@ -1489,13 +1489,15 @@ macromap<ContextT>::expand_macro(ContainerT &expanded,
 #if BOOST_WAVE_SUPPORT_VARIADICS_PLACEMARKERS != 0
 #if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS != 0
             if (boost::wave::need_named_variadics(ctx.get_language())) {
+                // named variadics can be completely left out
                 if ((parm_count_required >= 2) && 
                     T_ELLIPSIS == token_id(*(macro_def.macroparameters.end() - 1)) &&
                     T_IDENTIFIER == token_id(*(macro_def.macroparameters.end() - 2)))
-                    --parm_count_required; 
+                    parm_count_required -= 2;
             }
 #endif
 #endif
+
 #if BOOST_WAVE_SUPPORT_CPP2A
             if (boost::wave::need_cpp2a(ctx.get_language())) {
                 // Starting with C++20, variable arguments may be left out

--- a/include/boost/wave/util/cpp_macromap.hpp
+++ b/include/boost/wave/util/cpp_macromap.hpp
@@ -1486,6 +1486,14 @@ macromap<ContextT>::expand_macro(ContainerT &expanded,
                     macro_def.macroparameters.size(), seen_newline);
 
             std::size_t parm_count_required = macro_def.macroparameters.size();
+#if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS != 0
+            if (boost::wave::need_named_variadics(ctx.get_language())) {
+                if ((parm_count_required >= 2) && 
+                    T_ELLIPSIS == token_id(*(macro_def.macroparameters.end() - 1)) &&
+                    T_IDENTIFIER == token_id(*(macro_def.macroparameters.end() - 2)))
+                    --parm_count_required; 
+            }
+#endif
 #if BOOST_WAVE_SUPPORT_CPP2A
             if (boost::wave::need_cpp2a(ctx.get_language())) {
                 // Starting with C++20, variable arguments may be left out

--- a/include/boost/wave/util/cpp_macromap.hpp
+++ b/include/boost/wave/util/cpp_macromap.hpp
@@ -1486,17 +1486,6 @@ macromap<ContextT>::expand_macro(ContainerT &expanded,
                     macro_def.macroparameters.size(), seen_newline);
 
             std::size_t parm_count_required = macro_def.macroparameters.size();
-#if BOOST_WAVE_SUPPORT_VARIADICS_PLACEMARKERS != 0
-#if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS != 0
-            if (boost::wave::need_named_variadics(ctx.get_language())) {
-                // named variadics can be completely left out
-                if ((parm_count_required >= 2) && 
-                    T_ELLIPSIS == token_id(*(macro_def.macroparameters.end() - 1)) &&
-                    T_IDENTIFIER == token_id(*(macro_def.macroparameters.end() - 2)))
-                    parm_count_required -= 2;
-            }
-#endif
-#endif
 
 #if BOOST_WAVE_SUPPORT_CPP2A
             if (boost::wave::need_cpp2a(ctx.get_language())) {

--- a/include/boost/wave/util/macro_definition.hpp
+++ b/include/boost/wave/util/macro_definition.hpp
@@ -82,7 +82,8 @@ struct macro_definition {
             typename definition_container_type::iterator end = macrodefinition.end();
             typename definition_container_type::iterator it = macrodefinition.begin();
             typename ContextT::string_type va_args = "__VA_ARGS__";
-#if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS
+#if BOOST_WAVE_SUPPORT_VARIADICS_PLACEMARKERS != 0
+#if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS != 0
             if (need_named_variadics(ctx.get_language())) {
                 const_parameter_iterator_t cend = macroparameters.end();
                 const_parameter_iterator_t cbegin = macroparameters.begin();
@@ -92,6 +93,7 @@ struct macro_definition {
                     va_args = (*(cend-2)).get_value();
                 }
             }
+#endif
 #endif
 
             for (/**/; it != end; ++it) {
@@ -108,6 +110,7 @@ struct macro_definition {
                     for (typename parameter_container_type::size_type i = 0;
                         cit != cend; ++cit, ++i)
                     {
+#if BOOST_WAVE_SUPPORT_VARIADICS_PLACEMARKERS != 0
 #if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS
                         if (need_named_variadics(ctx.get_language()) &&
                             T_IDENTIFIER == token_id(*cit) &&
@@ -116,6 +119,7 @@ struct macro_definition {
                                 --i;
                                 continue;
                         }
+#endif
 #endif
                         if ((*it).get_value() == (*cit).get_value()) {
                             (*it).set_token_id(token_id(T_PARAMETERBASE+i));

--- a/include/boost/wave/util/macro_definition.hpp
+++ b/include/boost/wave/util/macro_definition.hpp
@@ -85,12 +85,9 @@ struct macro_definition {
 #if BOOST_WAVE_SUPPORT_VARIADICS_PLACEMARKERS != 0
 #if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS != 0
             if (need_named_variadics(ctx.get_language())) {
-                const_parameter_iterator_t cend = macroparameters.end();
-                const_parameter_iterator_t cbegin = macroparameters.begin();
-                if (macroparameters.size() >= 2 && 
-                    T_IDENTIFIER == token_id(*(cend-2)) &&
-                    T_ELLIPSIS == token_id(*(cend-1))) {
-                    va_args = (*(cend-2)).get_value();
+                if (macroparameters.size() > 0 && 
+                    T_GNU_NAMED_ELLIPSIS == token_id(macroparameters.back())) {
+                    va_args = macroparameters.back().get_value();
                 }
             }
 #endif
@@ -110,17 +107,6 @@ struct macro_definition {
                     for (typename parameter_container_type::size_type i = 0;
                         cit != cend; ++cit, ++i)
                     {
-#if BOOST_WAVE_SUPPORT_VARIADICS_PLACEMARKERS != 0
-#if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS != 0
-                        if (need_named_variadics(ctx.get_language()) &&
-                            T_IDENTIFIER == token_id(*cit) &&
-                            cit == cend - 2 &&
-                            T_ELLIPSIS == token_id(*(cit+1))) {
-                                --i;
-                                continue;
-                        }
-#endif
-#endif
                         if ((*it).get_value() == (*cit).get_value()) {
                             (*it).set_token_id(token_id(T_PARAMETERBASE+i));
                             break;
@@ -134,6 +120,16 @@ struct macro_definition {
                             (*it).set_token_id(token_id(T_EXTPARAMETERBASE+i));
                             break;
                         }
+#if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS != 0
+                        else if (need_named_variadics(ctx.get_language()) &&
+                            T_GNU_NAMED_ELLIPSIS == token_id(*cit) &&
+                            va_args == (*it).get_value())
+                        {
+                        // __VA_ARGS__ requires special handling
+                            (*it).set_token_id(token_id(T_EXTPARAMETERBASE+i));
+                            break;
+                        }
+#endif
 #if BOOST_WAVE_SUPPORT_VA_OPT != 0
                         else if (need_va_opt(ctx.get_language()) &&
                             T_ELLIPSIS == token_id(*cit) &&

--- a/include/boost/wave/util/macro_definition.hpp
+++ b/include/boost/wave/util/macro_definition.hpp
@@ -84,7 +84,7 @@ struct macro_definition {
             typename ContextT::string_type va_args = "__VA_ARGS__";
 #if BOOST_WAVE_SUPPORT_VARIADICS_PLACEMARKERS != 0
 #if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS != 0
-            if (need_named_variadics(ctx.get_language())) {
+            if (need_gnu_named_variadics(ctx.get_language())) {
                 if (macroparameters.size() > 0 && 
                     T_GNU_NAMED_ELLIPSIS == token_id(macroparameters.back())) {
                     va_args = macroparameters.back().get_value();
@@ -122,7 +122,7 @@ struct macro_definition {
                             break;
                         }
 #if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS != 0
-                        else if (need_named_variadics(ctx.get_language()) &&
+                        else if (need_gnu_named_variadics(ctx.get_language()) &&
                             T_GNU_NAMED_ELLIPSIS == token_id(*cit) &&
                             va_args == (*it).get_value())
                         {

--- a/include/boost/wave/util/macro_definition.hpp
+++ b/include/boost/wave/util/macro_definition.hpp
@@ -88,6 +88,7 @@ struct macro_definition {
                 if (macroparameters.size() > 0 && 
                     T_GNU_NAMED_ELLIPSIS == token_id(macroparameters.back())) {
                     va_args = macroparameters.back().get_value();
+                    va_args = va_args.substr(0, va_args.size()-3);
                 }
             }
 #endif
@@ -152,6 +153,13 @@ struct macro_definition {
             {
                 has_ellipsis = true;
             }
+#if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS != 0
+            if (macroparameters.size() > 0 && 
+                T_GNU_NAMED_ELLIPSIS == token_id(macroparameters.back())) 
+            {
+                has_ellipsis = true;
+            }
+#endif
 #endif
             replaced_parameters = true;     // do it only once
         }

--- a/include/boost/wave/util/macro_definition.hpp
+++ b/include/boost/wave/util/macro_definition.hpp
@@ -111,7 +111,7 @@ struct macro_definition {
                         cit != cend; ++cit, ++i)
                     {
 #if BOOST_WAVE_SUPPORT_VARIADICS_PLACEMARKERS != 0
-#if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS
+#if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS != 0
                         if (need_named_variadics(ctx.get_language()) &&
                             T_IDENTIFIER == token_id(*cit) &&
                             cit == cend - 2 &&

--- a/include/boost/wave/wave_config.hpp
+++ b/include/boost/wave/wave_config.hpp
@@ -159,6 +159,23 @@
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
+// Change the following, to enable the support for GNU named variadics:
+// #define(x...) x
+// By default this is disabled.
+#if !defined(BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS)
+#define BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS 0
+#endif
+
+
+///////////////////////////////////////////////////////////////////////////////
+// Warn the user if GNU named variadics are enabled without variadics support
+#if BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS != 0
+#if BOOST_WAVE_SUPPORT_VARIADICS_PLACEMARKERS == 0
+#warning "Boost.Wave: The support for GNU named variadics requires variadics support."
+#endif
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
 //  Allow the message body of the #error and #warning directives to be
 //  preprocessed before the diagnostic is issued.
 //

--- a/src/token_ids.cpp
+++ b/src/token_ids.cpp
@@ -232,6 +232,7 @@ static char const *tok_names[] = {
     /* 439 */   "T_CO_YIELD",
     /* 440 */   "T_REQUIRES",
     /* 441 */   "T_SPACESHIP",
+    /* 442 */   "T_GNU_NAMED_ELLIPSIS",
     };
 
     // make sure, I have not forgotten any commas (as I did more than once)
@@ -444,6 +445,7 @@ static char const *tok_values[] = {
     /* 439 */   "co_yield",
     /* 440 */   "requires",
     /* 441 */   "<=>",
+    /* 442 */   "",   // gnu_named_ellipsis
     };
 
     // make sure, I have not forgotten any commas (as I did more than once)


### PR DESCRIPTION
As mentioned in #164, named_variadics like `#define(x...) x` is widely used in projects like the Linux kernel.

This PR adds support for this feature.

- Options and exceptions.
This PR adds a `BOOST_WAVE_SUPPORT_GNU_NAMED_VARIADICS_PLACEMARKERS` and 
`support_option_named_variadics = 0x100000`.

When the macro is **enabled**, but the runtime option is **not**, it throws `bad_define_statement_named_va_args`, to remind the user to enable the option.
When the macro is **disabled**, it just reports `ill_formed.`

> I haven't figured out a way to inform the user that he/she needs to enable the macro and recompile for this feature to work...

- Lexer part.
I modified the lexer so it accept construct like `(ch_p(T_IDENTIFIER) >> *ppsp >> ch_p(T_ELLIPSIS))`, then, I used `token_node_d` to *compress* all these node into one, and `access_node_d` to modify the node information to `T_GNU_NAMED_VARIADIC`.

This helps deal with later replacement and expansion.
> Keeping all the nodes makes `(x, y...)` and `(x, y, ...)` indistinguishable in the later phases, as the `T_COMMA` does not generate any node.
> Unless we re-visit the original token seq in the later process,which leads to an egg-chicken problem.

- Expansion part.
I re-use most of the original codes.

- Testing
I have run some basic examples to ensure this feature works as expected.
The original test suite also passed, except for the one failure `t_5_007.cpp` that was introduced in #214, which I guess it's my local `libc` issue.


Let me know if there is any issue.

