### PR TITLE
Fix empty stringify under C++20

### DIFF
--- a/include/boost/wave/util/cpp_macromap.hpp
+++ b/include/boost/wave/util/cpp_macromap.hpp
@@ -1262,27 +1262,39 @@ macromap<ContextT>::expand_replacement_list(
             else if (adjacent_stringize &&
                     !IS_CATEGORY(*cit, WhiteSpaceTokenType))
             {
-                // stringize the current argument
-                BOOST_ASSERT(!arguments[i].empty());
-
-                // safe a copy of the first tokens position (not a reference!)
-                position_type pos((*arguments[i].begin()).get_position());
-
-#if BOOST_WAVE_SUPPORT_VARIADICS_PLACEMARKERS != 0
-                if (is_ellipsis && boost::wave::need_variadics(ctx.get_language())) {
-                    impl::trim_sequence_left(arguments[i]);
-                    impl::trim_sequence_right(arguments.back());
-                    expanded.push_back(token_type(T_STRINGLIT,
-                        impl::as_stringlit(arguments, i, pos), pos));
-                }
+#if BOOST_WAVE_SUPPORT_CPP2A != 0
+                if (i >= arguments.size()) {
+                    if (boost::wave::need_cpp2a(ctx.get_language())) {
+                        // no argument supplied; do nothing
+                        adjacent_stringize = false;
+                    } else {
+                        BOOST_WAVE_THROW_CTX(ctx, preprocess_exception,
+                        too_few_macroarguments, (*cit).get_value().c_str(),
+                        main_pos);
+                    }
+                } 
                 else
 #endif
                 {
-                    impl::trim_sequence(arguments[i]);
-                    expanded.push_back(token_type(T_STRINGLIT,
-                        impl::as_stringlit(arguments[i], pos), pos));
+                    // safe a copy of the first tokens position (not a reference!)
+                    position_type pos((*arguments[i].begin()).get_position());
+
+#if BOOST_WAVE_SUPPORT_VARIADICS_PLACEMARKERS != 0
+                    if (is_ellipsis && boost::wave::need_variadics(ctx.get_language())) {
+                        impl::trim_sequence_left(arguments[i]);
+                        impl::trim_sequence_right(arguments.back());
+                        expanded.push_back(token_type(T_STRINGLIT,
+                            impl::as_stringlit(arguments, i, pos), pos));
+                    }
+                    else
+#endif
+                    {
+                        impl::trim_sequence(arguments[i]);
+                        expanded.push_back(token_type(T_STRINGLIT,
+                            impl::as_stringlit(arguments[i], pos), pos));
+                    }
+                    adjacent_stringize = false;
                 }
-                adjacent_stringize = false;
             }
             else {
                 // simply copy the original argument (adjacent '##' or '#')

--- a/include/boost/wave/util/cpp_macromap.hpp
+++ b/include/boost/wave/util/cpp_macromap.hpp
@@ -1266,6 +1266,9 @@ macromap<ContextT>::expand_replacement_list(
                 if (i >= arguments.size()) {
                     // no argument supplied; do nothing (only c20 should reach here)
                     BOOST_ASSERT(boost::wave::need_cpp2a(ctx.get_language()));
+                    position_type last_valid(arguments.back().back().get_position());
+                    // insert a empty string
+                    expanded.push_back(token_type(T_STRINGLIT, "\"\"", last_valid));
                     adjacent_stringize = false;
                 } 
                 else

--- a/include/boost/wave/util/cpp_macromap.hpp
+++ b/include/boost/wave/util/cpp_macromap.hpp
@@ -1269,7 +1269,6 @@ macromap<ContextT>::expand_replacement_list(
                     position_type last_valid(arguments.back().back().get_position());
                     // insert a empty string
                     expanded.push_back(token_type(T_STRINGLIT, "\"\"", last_valid));
-                    adjacent_stringize = false;
                 } 
                 else
 #endif
@@ -1293,8 +1292,8 @@ macromap<ContextT>::expand_replacement_list(
                         expanded.push_back(token_type(T_STRINGLIT,
                             impl::as_stringlit(arguments[i], pos), pos));
                     }
-                    adjacent_stringize = false;
                 }
+                adjacent_stringize = false;
             }
             else {
                 // simply copy the original argument (adjacent '##' or '#')

--- a/include/boost/wave/util/cpp_macromap.hpp
+++ b/include/boost/wave/util/cpp_macromap.hpp
@@ -1264,18 +1264,15 @@ macromap<ContextT>::expand_replacement_list(
             {
 #if BOOST_WAVE_SUPPORT_CPP2A != 0
                 if (i >= arguments.size()) {
-                    if (boost::wave::need_cpp2a(ctx.get_language())) {
-                        // no argument supplied; do nothing
-                        adjacent_stringize = false;
-                    } else {
-                        BOOST_WAVE_THROW_CTX(ctx, preprocess_exception,
-                        too_few_macroarguments, (*cit).get_value().c_str(),
-                        main_pos);
-                    }
+                    // no argument supplied; do nothing (only c20 should reach here)
+                    BOOST_ASSERT(boost::wave::need_cpp2a(ctx.get_language()));
+                    adjacent_stringize = false;
                 } 
                 else
 #endif
                 {
+                    // shouldn't be oob (w.o. cpp20)
+                    BOOST_ASSERT(i < arguments.size() && !arguments[i].empty());
                     // safe a copy of the first tokens position (not a reference!)
                     position_type pos((*arguments[i].begin()).get_position());
 

--- a/test/testwave/testfiles/t_8_004.cpp
+++ b/test/testwave/testfiles/t_8_004.cpp
@@ -22,3 +22,18 @@ sizedvec(int, foo, 12);
 //R #line 24 "t_8_004.cpp"
 //R std::vector<double> bar( 3 , 42.0);
 sizedvec(double, bar, 3, 42.0);
+
+// test omitting trailing comma when expanding a macro with both variadic and
+// non-variadic parameters where no variadic parameters are supplied
+// (allowed starting in C++20)
+#define MACRO1(x, ...)  x -> __VA_ARGS__
+#define MACRO2(x, ...) #x#__VA_ARGS__
+#define MACRO3(x, ...) x##__VA_ARGS__
+
+//R #line 34 "t_8_004.cpp"
+MACRO1(1,)  //R 1 -> 
+MACRO2(1,)  //R "1""" 
+MACRO3(1,)  //R 1 
+MACRO1(1)   //R 1 -> 
+MACRO2(1)   //R "1""" 
+MACRO3(1)   //R 1 


### PR DESCRIPTION
Fix #220.

Check if the variadics variable is omitted; put an empty string if so.