### PR TITLE
Line directive emitted in middle of multiline string

### DIFF
--- a/include/boost/wave/util/cpp_iterator.hpp
+++ b/include/boost/wave/util/cpp_iterator.hpp
@@ -327,12 +327,10 @@ protected:
     void on_define(parse_node_type const &node);
     void on_undefine(lexer_type const &it);
 
-    void on_ifdef(result_type const& found_directive,
-        typename parse_tree_type::const_iterator const &begin,
-        typename parse_tree_type::const_iterator const &end);
-    void on_ifndef(result_type const& found_directive,
-        typename parse_tree_type::const_iterator const &begin,
-        typename parse_tree_type::const_iterator const &end);
+    void on_ifdef(result_type const& found_directive, lexer_type const &it);
+//         typename parse_tree_type::const_iterator const &end);
+    void on_ifndef(result_type const& found_directive, lexer_type const& it);
+//         typename parse_tree_type::const_iterator const &end);
     void on_else();
     void on_endif();
     void on_illformed(typename result_type::string_type s);
@@ -1260,6 +1258,23 @@ pp_iterator_functor<ContextT>::handle_pp_directive(IteratorT &it)
             call_hook_in_skip = false;
             break;
 
+        case T_PP_IFDEF:                // #ifdef
+            if (!impl::call_found_directive_hook(ctx, *it) &&
+                extract_identifier(it))
+            {
+                on_ifdef(directive, it);
+            }
+            call_hook_in_skip = false;
+            break;
+        case T_PP_IFNDEF:               // #ifndef
+            if (!impl::call_found_directive_hook(ctx, *it) &&
+                extract_identifier(it))
+            {
+                on_ifndef(directive, it);
+            }
+            call_hook_in_skip = false;
+            break;
+
 #if BOOST_WAVE_SUPPORT_MS_EXTENSIONS != 0
 //         case T_MSEXT_PP_REGION:         // #region ...
 //             break;
@@ -1454,13 +1469,13 @@ pp_iterator_functor<ContextT>::dispatch_directive(
 //         on_undefine(*nodeval.begin());
 //         break;
 //
-    case T_PP_IFDEF:        // #ifdef
-        on_ifdef(found_directive, begin_child_it, end_child_it);
-        break;
+    // case T_PP_IFDEF:        // #ifdef
+    //     on_ifdef(found_directive, begin_child_it, end_child_it);
+    //     break;
 
-    case T_PP_IFNDEF:       // #ifndef
-        on_ifndef(found_directive, begin_child_it, end_child_it);
-        break;
+    // case T_PP_IFNDEF:       // #ifndef
+    //     on_ifndef(found_directive, begin_child_it, end_child_it);
+    //     break;
 
     case T_PP_IF:           // #if
         on_if(found_directive, begin_child_it, end_child_it);
@@ -1848,23 +1863,26 @@ pp_iterator_functor<ContextT>::on_undefine (lexer_type const &it)
 template <typename ContextT>
 inline void
 pp_iterator_functor<ContextT>::on_ifdef(
-    result_type const& found_directive,
-    typename parse_tree_type::const_iterator const &begin,
-    typename parse_tree_type::const_iterator const &end)
+    result_type const& found_directive, lexer_type const &it)
+//     typename parse_tree_type::const_iterator const &it)
+//     typename parse_tree_type::const_iterator const &end)
 {
-    get_token_value<result_type, parse_node_type> get_value;
-    token_sequence_type toexpand;
-
-    std::copy(make_ref_transform_iterator((*begin).children.begin(), get_value),
-              make_ref_transform_iterator((*begin).children.end(), get_value),
-              std::inserter(toexpand, toexpand.end()));
+    // get_token_value<result_type, parse_node_type> get_value;
+    // token_sequence_type toexpand;
+    //
+    //     std::copy(make_ref_transform_iterator((*begin).children.begin(), get_value),
+    //         make_ref_transform_iterator((*begin).children.end(), get_value),
+    //         std::inserter(toexpand, toexpand.end()));
 
     bool is_defined = false;
+    token_sequence_type directive;
+
+    directive.insert(directive.end(), *it);
 
     do {
-        is_defined = ctx.is_defined_macro(toexpand.begin(), toexpand.end());
+        is_defined = ctx.is_defined_macro((*it).get_value()); // toexpand.begin(), toexpand.end());
     } while (ctx.get_hooks().evaluated_conditional_expression(ctx.derived(),
-             found_directive, toexpand, is_defined));
+             found_directive, directive, is_defined));
     ctx.enter_if_block(is_defined);
 }
 
@@ -1876,23 +1894,26 @@ pp_iterator_functor<ContextT>::on_ifdef(
 template <typename ContextT>
 inline void
 pp_iterator_functor<ContextT>::on_ifndef(
-    result_type const& found_directive,
-    typename parse_tree_type::const_iterator const &begin,
-    typename parse_tree_type::const_iterator const &end)
+    result_type const& found_directive, lexer_type const &it)
+//     typename parse_tree_type::const_iterator const &it)
+//     typename parse_tree_type::const_iterator const &end)
 {
-    get_token_value<result_type, parse_node_type> get_value;
-    token_sequence_type toexpand;
-
-    std::copy(make_ref_transform_iterator((*begin).children.begin(), get_value),
-              make_ref_transform_iterator((*begin).children.end(), get_value),
-              std::inserter(toexpand, toexpand.end()));
+    // get_token_value<result_type, parse_node_type> get_value;
+    // token_sequence_type toexpand;
+    //
+    //     std::copy(make_ref_transform_iterator((*begin).children.begin(), get_value),
+    //         make_ref_transform_iterator((*begin).children.end(), get_value),
+    //         std::inserter(toexpand, toexpand.end()));
 
     bool is_defined = false;
+    token_sequence_type directive;
+
+    directive.insert(directive.end(), *it);
 
     do {
-        is_defined = ctx.is_defined_macro(toexpand.begin(), toexpand.end());
+        is_defined = ctx.is_defined_macro((*it).get_value()); // toexpand.begin(), toexpand.end());
     } while (ctx.get_hooks().evaluated_conditional_expression(ctx.derived(),
-             found_directive, toexpand, is_defined));
+             found_directive, directive, is_defined));
     ctx.enter_if_block(!is_defined);
 }
 

--- a/test/testwave/testfiles/t_9_029.cpp
+++ b/test/testwave/testfiles/t_9_029.cpp
@@ -1,0 +1,45 @@
+/*=============================================================================
+    Boost.Wave: A Standard compliant C++ preprocessor library
+    http://www.boost.org/
+
+    Copyright (c) 2001-2012 Hartmut Kaiser. Distributed under the Boost
+    Software License, Version 1.0. (See accompanying file
+    LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+=============================================================================*/
+
+// ifdef and ifndef should not emit line directives in the middle of a multiline string
+
+"a1
+#ifdef A
+    a2a"
+#else
+    a12b
+    a13"
+#endif
+
+"b1
+#ifndef A
+    b2a"
+#else
+    b2b
+    b3"
+#endif
+
+c
+
+//R #line 12 "t_9_029.cpp"
+//R "a1
+//R a12b
+//R a13"
+//R #line 20 "t_9_029.cpp"
+//R "b1
+//R b2a"
+//R #line 28 "t_9_029.cpp"
+//R c
+
+//H 10: t_9_029.cpp(13): #ifdef
+//H 11: t_9_029.cpp(13): #ifdef A: 0
+//H 10: t_9_029.cpp(18): #endif
+//H 10: t_9_029.cpp(21): #ifndef
+//H 11: t_9_029.cpp(21): #ifndef A: 0
+//H 10: t_9_029.cpp(23): #else

--- a/test/testwave/testfiles/test.cfg
+++ b/test/testwave/testfiles/test.cfg
@@ -278,3 +278,4 @@ t_9_025.cpp
 t_9_026.cpp
 # t_9_027.cpp currently disabled, expected fail only on windows
 # t_9_028.cpp currently disabled, expected fail only on windows
+t_9_029.cpp


### PR DESCRIPTION
Attempts to address https://github.com/boostorg/wave/issues/225

PR reverts the changes to cpp_iterator.hpp that were introduced in https://github.com/boostorg/wave/pull/140

