### PR TITLE
Avoid including deprecated atomic_count.hpp header

### DIFF
--- a/samples/real_positions/real_position_token.hpp
+++ b/samples/real_positions/real_position_token.hpp
@@ -17,7 +17,7 @@
 #include <boost/wave/util/file_position.hpp>
 #include <boost/wave/token_ids.hpp>  
 #include <boost/wave/language_support.hpp>
-#include <boost/detail/atomic_count.hpp>
+#include <boost/smart_ptr/detail/atomic_count.hpp>
 #include <boost/optional.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
`boost/detail/atomic_count.hpp` was moved to `boost/smart_ptr/detail` and the old header is deprecated and emits warnings.