### PR TITLE
GHA: Use Ubuntu 24.04 for clang test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
             buildtype: "boost"
             packages: ""
             packages_to_remove: ""
-            os: "ubuntu-20.04"
+            os: "ubuntu-24.04"
             cxx: "clang++"
             sources: ""
             llvm_os: ""


### PR DESCRIPTION
GitHub removes the Ubuntu 20 runners

Currently there are random intended failures (brownout phase):
> This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. 

As the Clang version doesn't seem to matter just update to the latest OS