### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,6 @@ target_link_libraries(boost_wave
     Boost::serialization
     Boost::smart_ptr
     Boost::spirit
-    Boost::static_assert
     Boost::throw_exception
     Boost::type_traits
 )

--- a/build.jam
+++ b/build.jam
@@ -22,7 +22,6 @@ constant boost_dependencies :
     /boost/serialization//boost_serialization
     /boost/smart_ptr//boost_smart_ptr
     /boost/spirit//boost_spirit
-    /boost/static_assert//boost_static_assert
     /boost/throw_exception//boost_throw_exception
     /boost/type_traits//boost_type_traits ;
 


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.