### PR TITLE
Fix slex and lexertl example token counts for MSVC

### DIFF
--- a/samples/cpp_tokens/slex/cpp_slex_lexer.hpp
+++ b/samples/cpp_tokens/slex/cpp_slex_lexer.hpp
@@ -51,7 +51,7 @@ namespace lexer {
 //  The following numbers are the array sizes of the token regex's which we
 //  need to specify to make the CW compiler happy (at least up to V9.5).
 #if BOOST_WAVE_SUPPORT_MS_EXTENSIONS != 0
-#define INIT_DATA_SIZE              175
+#define INIT_DATA_SIZE              176
 #else
 #define INIT_DATA_SIZE              159
 #endif

--- a/samples/list_includes/lexertl/lexertl_lexer.hpp
+++ b/samples/list_includes/lexertl/lexertl_lexer.hpp
@@ -52,7 +52,7 @@ namespace boost { namespace wave { namespace cpplexer { namespace lexertl
 //  The following numbers are the array sizes of the token regex's which we
 //  need to specify to make the CW compiler happy (at least up to V9.5).
 #if BOOST_WAVE_SUPPORT_MS_EXTENSIONS != 0
-#define INIT_DATA_SIZE              176
+#define INIT_DATA_SIZE              177
 #else
 #define INIT_DATA_SIZE              160
 #endif


### PR DESCRIPTION
The non-MS-extension case was updated correctly but this was missed until Appveyor CI