### PR TITLE
Update to new(er) macos build following boost-ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,14 +200,14 @@ jobs:
           - name: "TOOLSET=clang CXXSTD=11,14,17,20 Job 5"
             buildtype: "boost"
             packages: ""
-            os: "macos-13"
+            os: "macos-15"
             cxx: "clang++"
             sources: ""
             llvm_os: ""
             llvm_ver: ""
-            xcode_version: 14.2.0
-            toolset: "clang"
-            cxxstd: "11,14,17,20"
+            xcode_version: 16.2.0
+            toolset: "clang-16"
+            cxxstd: "11,14,17,20,2b"
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
The macos target has been failing due to a lack of GHA runners for the obsolete config